### PR TITLE
Recipes use gem forge tags

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:storage_blocks/ruby",
+    "#forge:storage_blocks/sapphire"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/ruby.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/ruby.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pokecube_legends:ruby_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/sapphire.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/sapphire.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pokecube_legends:sapphire_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores.json
+++ b/src/main/resources/data/forge/tags/items/ores.json
@@ -1,0 +1,10 @@
+{
+    "replace": false,
+    "values": [
+        "#forge:ores/sapphire",
+        "#forge:ores/ruby"
+    ],
+    "optional": [
+        "pokecube:fossilstone"
+    ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/ruby.json
+++ b/src/main/resources/data/forge/tags/items/ores/ruby.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "pokecube_legends:ruby_ore"
+    ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/sapphire.json
+++ b/src/main/resources/data/forge/tags/items/ores/sapphire.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "pokecube_legends:sapphire_ore"
+    ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:storage_blocks/ruby",
+    "#forge:storage_blocks/sapphire"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/ruby.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/ruby.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pokecube_legends:ruby_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/sapphire.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/sapphire.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "pokecube_legends:sapphire_block"
+  ]
+}

--- a/src/main/resources/data/pokecube_legends/recipes/blueorb.json
+++ b/src/main/resources/data/pokecube_legends/recipes/blueorb.json
@@ -7,13 +7,13 @@
   ],
   "key": {
     "G": {
-      "item": "pokecube_legends:sapphire"
+      "tag": "forge:gems/sapphire"
     },
     "A": {
       "item": "pokecube_legends:grayorb"
     },
     "R": {
-      "item": "pokecube_legends:sapphire_block"
+      "tag": "forge:storage_blocks/sapphire"
     }
   },
   "result": {

--- a/src/main/resources/data/pokecube_legends/recipes/oceanorb.json
+++ b/src/main/resources/data/pokecube_legends/recipes/oceanorb.json
@@ -10,7 +10,7 @@
       "item": "pokecube_legends:legendaryorb"
     },
     "R": {
-      "item": "pokecube_legends:sapphire"
+      "tag": "forge:gems/sapphire"
     }
   },
   "result": {

--- a/src/main/resources/data/pokecube_legends/recipes/redorb.json
+++ b/src/main/resources/data/pokecube_legends/recipes/redorb.json
@@ -7,13 +7,13 @@
   ],
   "key": {
     "G": {
-      "item": "pokecube_legends:ruby"
+      "tag": "forge:gems/ruby"
     },
     "A": {
       "item": "pokecube_legends:grayorb"
     },
     "R": {
-      "item": "pokecube_legends:ruby_block"
+      "tag": "forge:storage_blocks/ruby"
     }
   },
   "result": {


### PR DESCRIPTION
- Recipes that used sapphires or rubies now use the respective forge tag.
- Sapphire & Ruby blocks were also give tags.
- Added item tags for ores that were previously missed.