### PR TITLE
Fix guard AI, client-side auto-recall, and replant berry placement

### DIFF
--- a/src/pokecube/java/pokecube/core/ai/tasks/Tasks.java
+++ b/src/pokecube/java/pokecube/core/ai/tasks/Tasks.java
@@ -76,7 +76,7 @@ public class Tasks
                 MemoryModules.MOVE_TARGET.get(), MemoryModules.LEAP_TARGET.get(), MemoryModules.COMBAT_CENTRE.get(),
                 MemoryModules.TIMER_LEAP.get(), MemoryModules.TIMER_DODGE.get(), MemoryModules.TIMER_SWAPMOVE.get(),
                 MemoryModules.ATTACKDELAY.get(), MemoryModules.TARGETOWNER.get(), MemoryModules.ATTACKTARGETID.get(),
-                MemoryModules.TIMER_FORGETTARGET.get(), MemoryModules.TIMER_SWAPTARGET.get(),
+                MemoryModules.TIMER_FORGETTARGET.get(), MemoryModules.TIMER_SWAPTARGET.get(), MemoryModules.TRACKEDTARGET.get(),
                 MemoryModules.GATHER_DETAILS.get(), MemoryModules.CALLED_HELP.get(), MemoryModules.PATH,
                 MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE, MemoryModules.MATE_TARGET, MemoryModules.WALK_TARGET,
                 MemoryModules.LOOK_TARGET, MemoryModules.EGG.get(), MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES,

--- a/src/pokecube/java/pokecube/core/client/EventsHandlerClient.java
+++ b/src/pokecube/java/pokecube/core/client/EventsHandlerClient.java
@@ -163,7 +163,13 @@ public class EventsHandlerClient
             final IPokemob mob = GuiDisplayPokecubeInfo.instance().getCurrentPokemob();
             if (mob != null && mob.getEntity().isAlive() && mob.getEntity().isAddedToLevel()
                     && event.getEntity().distanceTo(mob.getEntity()) > PokecubeCore.getConfig().autoRecallDistance)
-                mob.onRecall();
+            {
+                // Only auto-recall if the Pokemon should be following
+                // Don't auto-recall Pokemon that are staying, guarding, or not set to follow
+                if (!mob.getGeneralState(GeneralStates.STAYING)
+                        && !mob.inCombat())
+                    mob.onRecall();
+            }
         }
         control:
         if (event.getEntity().isPassenger() && Minecraft.getInstance().screen == null

--- a/src/pokecube/java/pokecube/core/items/berries/ItemBerry.java
+++ b/src/pokecube/java/pokecube/core/items/berries/ItemBerry.java
@@ -170,11 +170,17 @@ public class ItemBerry extends BlockItem implements IMoveConstants
         // Only if we can place it
         if (!playerIn.mayUseItemAt(pos.relative(side), side, stack)) return InteractionResult.FAIL;
 
+	// Is this placeable on the location
         TriState placeable = block.canSustainPlant(state, worldIn, pos, Direction.UP,
                 this.getPlacementState(new BlockPlaceContext(context)));
-        if (placeable != TriState.FALSE)
+
+        // Does this survive at the location
+        BlockState cropState = BerryManager.getCrop(this).defaultBlockState();
+        BlockPos plantPos = pos.above();
+
+        if (placeable != TriState.FALSE && cropState.canSurvive(worldIn, plantPos))
         {
-            worldIn.setBlockAndUpdate(pos.above(), BerryManager.getCrop(this).defaultBlockState());
+            worldIn.setBlockAndUpdate(plantPos, cropState);
             stack.split(1);
             return InteractionResult.SUCCESS;
         }


### PR DESCRIPTION
Guard AI was not attacking when enabled. Just needed a memory module added to the AI, as the Guard AI required it.

Auto-recall did not check if the pokemon was supposed to be staying at its location, which caused random recalls when client entered/exited the range of the recall.

Berry placement did not check if the berry plant would survive at its location before placing it, sometimes placing the plant in midair when the pokemob did harvest tags.