### PR TITLE
Hacky Bee Fix

### DIFF
--- a/src/pokecube/java/pokecube/api/entity/CapabilityInhabitable.java
+++ b/src/pokecube/java/pokecube/api/entity/CapabilityInhabitable.java
@@ -161,4 +161,13 @@ public class CapabilityInhabitable
         if (!(in instanceof BlockEntity tile)) return null;
         return new HabitatProvider(tile);
     }
+
+    public static IHabitat makeProviderFromResource(final IAttachmentHolder in, ResourceLocation defaultResource)
+    {
+        if (!(in instanceof BlockEntity tile)) return null;
+        if (CapabilityInhabitable.REGISTRY.containsKey(defaultResource)) {
+            return new HabitatProvider(tile, REGISTRY.get(defaultResource).apply(tile));
+        }
+        return new HabitatProvider(tile);
+    }
 }

--- a/src/pokecube/java/pokecube/api/entity/pokemob/PokemobCaps.java
+++ b/src/pokecube/java/pokecube/api/entity/pokemob/PokemobCaps.java
@@ -58,6 +58,16 @@ public class PokemobCaps
         return null;
     }
 
+    public static IHabitat getHabitatFor(IAttachmentHolder entityIn, ResourceLocation defaultHabitat)
+    {
+        if (entityIn == null) return null;
+        if (!entityIn.hasData(INHABITABLE) && defaultHabitat != null) {
+            entityIn.setData(INHABITABLE, CapabilityInhabitable.makeProviderFromResource(entityIn, defaultHabitat));
+        }
+        if (entityIn.hasData(INHABITABLE)) return entityIn.getData(INHABITABLE);
+        return null;
+    }
+
     public static IInhabitor getInhabitorFor(IAttachmentHolder entityIn)
     {
         if (entityIn == null) return null;

--- a/src/pokecube/java/pokecube/core/utils/CapHolders.java
+++ b/src/pokecube/java/pokecube/core/utils/CapHolders.java
@@ -1,5 +1,6 @@
 package pokecube.core.utils;
 
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.attachment.IAttachmentHolder;
 import pokecube.api.ai.IInhabitor;
 import pokecube.api.blocks.IInhabitable;
@@ -7,11 +8,17 @@ import pokecube.api.entity.pokemob.PokemobCaps;
 import pokecube.core.ai.routes.GuardAICapability;
 import pokecube.core.ai.routes.IGuardAICapability;
 
+
 public class CapHolders
 {
     public static IInhabitor getInhabitor(final IAttachmentHolder in)
     {
         return PokemobCaps.getInhabitorFor(in);
+    }
+
+    public static IInhabitable getInhabitable(final IAttachmentHolder in, ResourceLocation defaultHabitat)
+    {
+        return PokemobCaps.getHabitatFor(in, defaultHabitat);
     }
 
     public static IInhabitable getInhabitable(IAttachmentHolder in)

--- a/src/pokecube/java/pokecube/gimmicks/nests/NestTasks.java
+++ b/src/pokecube/java/pokecube/gimmicks/nests/NestTasks.java
@@ -13,6 +13,7 @@ import pokecube.core.PokecubeCore;
 import pokecube.gimmicks.nests.tasks.ants.AntTasks;
 import pokecube.gimmicks.nests.tasks.ants.AntTasks.AntInhabitor;
 import pokecube.gimmicks.nests.tasks.bees.BeeTasks;
+import pokecube.gimmicks.nests.tasks.bees.BeeTasks.BeeInhabitor;
 import pokecube.gimmicks.nests.tasks.burrows.BurrowTasks;
 import thut.api.data.HolderProvider;
 import thut.api.item.ItemList;
@@ -68,7 +69,7 @@ public class NestTasks
             {
                 if (!(t instanceof Mob mob)) return null;
                 if (!mob.getType().is(EntityTypeTags.BEEHIVE_INHABITORS)) return null;
-                return new AntInhabitor(mob);
+                return new BeeInhabitor(mob);
             }
 
             @Override

--- a/src/pokecube/java/pokecube/gimmicks/nests/tasks/bees/sensors/HiveSensor.java
+++ b/src/pokecube/java/pokecube/gimmicks/nests/tasks/bees/sensors/HiveSensor.java
@@ -21,6 +21,7 @@ import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.ai.village.poi.PoiRecord;
 import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.resources.ResourceLocation;
 import pokecube.api.blocks.IInhabitable;
 import pokecube.core.utils.CapHolders;
 import pokecube.gimmicks.nests.tasks.bees.BeeTasks;
@@ -52,14 +53,14 @@ public class HiveSensor extends Sensor<Mob>
     {
         final IHiveEnterer vanillaHives = (entityIn, tile) -> {
             if (!(tile instanceof BeehiveBlockEntity)) return false;
-            final IInhabitable habitat = CapHolders.getInhabitable(tile);
+            final IInhabitable habitat = CapHolders.getInhabitable(tile, ResourceLocation.parse("pokecube:vanilla_bees"));
             return habitat != null && habitat.onEnterHabitat(entityIn);
         };
         HiveSensor.hiveEnterers.add(vanillaHives);
 
         final IHiveSpaceCheck vanillaCheck = (entityIn, tile) -> {
             if (!(tile instanceof BeehiveBlockEntity)) return false;
-            final IInhabitable habitat = CapHolders.getInhabitable(tile);
+            final IInhabitable habitat = CapHolders.getInhabitable(tile, ResourceLocation.parse("pokecube:vanilla_bees"));
             return habitat != null && habitat.canEnterHabitat(entityIn);
         };
         HiveSensor.hiveSpaceCheckers.add(vanillaCheck);


### PR DESCRIPTION
Adds the Neoforge data attachment to the beehives/nests whenever they're examined if they don't exist already.

Changed the inhabitor - they're bees, not ants.

This has been a little buggy, sometimes they still won't recognize the beehive and the beehive needs to be broken and re-placed.