### PR TITLE
Preserve Pokémob egg incubation time across item transfers

### DIFF
--- a/src/pokecube/java/pokecube/core/items/pokemobeggs/EntityPokemobEgg.java
+++ b/src/pokecube/java/pokecube/core/items/pokemobeggs/EntityPokemobEgg.java
@@ -19,6 +19,7 @@ import net.minecraft.world.phys.Vec3;
 import pokecube.api.entity.pokemob.IPokemob;
 import pokecube.api.entity.pokemob.PokemobCaps;
 import pokecube.api.events.EggEvent;
+import pokecube.api.items.EggInfo;
 import pokecube.api.moves.Battle;
 import pokecube.core.PokecubeCore;
 import thut.api.maths.Vector3;
@@ -60,7 +61,7 @@ public class EntityPokemobEgg extends AgeableMob
         final Entity e = source.getDirectEntity();
         if (!this.level().isClientSide && e instanceof Player player)
         {
-            final ItemStack itemstack = this.getMainHandItem();
+            final ItemStack itemstack = this.syncEggTime();
             final int i = itemstack.getCount();
             if (this.mother != null && this.mother.getOwner() != player)
                 Battle.createOrAddToBattle(this.mother.getEntity(), player);
@@ -120,7 +121,7 @@ public class EntityPokemobEgg extends AgeableMob
     @Override
     public ItemStack getPickedResult(final HitResult target)
     {
-        return this.getMainHandItem().copy();
+        return this.syncEggTime().copy();
     }
 
     /**
@@ -165,7 +166,7 @@ public class EntityPokemobEgg extends AgeableMob
     public InteractionResult interactAt(final Player player, final Vec3 pos, final InteractionHand hand)
     {
         if (this.delayBeforeCanPickup > 0) return InteractionResult.FAIL;
-        final ItemStack itemstack = this.getMainHandItem();
+        final ItemStack itemstack = this.syncEggTime();
         final int i = itemstack.getCount();
         if (this.mother != null && this.mother.getOwner() != player)
             Battle.createOrAddToBattle(this.mother.getEntity(), player);
@@ -198,8 +199,18 @@ public class EntityPokemobEgg extends AgeableMob
     public EntityPokemobEgg setStack(final ItemStack stack)
     {
         this.setItemInHand(InteractionHand.MAIN_HAND, stack);
-        this.setAge(PokemobCaps.getEggContents(stack).getTime());
+        final EggInfo contents = PokemobCaps.getEggContents(stack);
+        if (contents.tag().contains("time")) this.setAge(contents.getTime());
+        else this.syncEggTime();
         return this;
+    }
+
+    private ItemStack syncEggTime()
+    {
+        final ItemStack stack = this.getMainHandItem();
+        final EggInfo contents = PokemobCaps.getEggContents(stack);
+        stack.set(PokemobCaps.POKEEGG_DATA, new EggInfo(contents.tag().copy()).withTime(this.getAge()));
+        return stack;
     }
 
     public EntityPokemobEgg setStackByParents(final Entity placer, final IPokemob father)
@@ -264,7 +275,7 @@ public class EntityPokemobEgg extends AgeableMob
         if (te instanceof HopperBlockEntity hopper)
         {
             final ItemEntity item = new ItemEntity(this.level(), this.getX(), this.getY(), this.getZ(),
-                    this.getMainHandItem());
+                    this.syncEggTime());
             if (HopperBlockEntity.addItem(hopper, item)) this.discard();
         }
     }


### PR DESCRIPTION
## Summary

- Synchronize an egg entity's current incubation age back into its `pokecube:pokeegg` item component before it becomes an item.
- Restore the stored incubation time when an egg item becomes an egg entity again.
- Initialize eggs without stored time from the entity's randomized hatch timer instead of the component's fixed fallback.

## Root cause

Egg incubation progresses on the egg entity's `Age`, while the item form stores its timer in `EggInfo`. The entity-to-item paths returned the held stack without updating that component, so pickup or hopper transfer could discard the entity's incubation progress. Dropping the item again then restored stale data or the `-24000` fallback rather than the current timer.

## Impact

Eggs now keep their remaining incubation time when picked up and dropped again or moved through a hopper. Newly initialized eggs still use the configured randomized hatch time.

## Validation

- Ran `./gradlew clean build --no-daemon` successfully.
- Verified the assembled AIO contains the modified egg class and the compiled bytecode contains all intended synchronization call sites.
- Tested direct hand pickup and re-dropping in-game; incubation progress was preserved.
- Tested hopper insertion, retrieval, and re-dropping in-game; incubation progress was preserved.
