### PR TITLE
Fix Pokémob icon and form rendering in Xaero, JEI, and Pokédex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,150 @@ sourceSets.main.resources { srcDir 'src/compat/resources' }
 sourceSets.main.java { srcDir 'src/compat/java' }
 //*/
 
+def xaeroPokemobIconSource = file('PokecubeMobs/pokecube_mobs/assets/pokecube_mobs/textures/entity_icon/pokemob')
+def xaeroPokedexEntrySource = file('PokecubeMobs/pokecube_mobs/data/pokecube_mobs/database/pokemobs/pokedex_entries')
+def xaeroIconDefinitionOutput = layout.buildDirectory.dir('generated/resources/xaero-pokemob-icons')
+
+def generateXaeroPokemobIconResources = tasks.register('generateXaeroPokemobIconResources') {
+    inputs.files(fileTree(xaeroPokedexEntrySource) { include '*.json' })
+    inputs.files(fileTree(xaeroPokemobIconSource) { include '*.png' })
+    outputs.dir(xaeroIconDefinitionOutput)
+
+    doLast {
+        final File outputRoot = xaeroIconDefinitionOutput.get().asFile
+        final File definitionRoot = new File(outputRoot, 'assets/xaerominimap/entity/icon/definition/pokecube')
+        final File spriteRoot = new File(outputRoot, 'assets/xaerominimap/entity/icon/sprite/pokecube')
+        delete(outputRoot)
+        definitionRoot.mkdirs()
+        spriteRoot.mkdirs()
+
+        final def json = new groovy.json.JsonSlurper()
+        final List<Map<String, Object>> entries = fileTree(xaeroPokedexEntrySource) {
+            include '*.json'
+        }.files.collect { File entryFile ->
+            final Map<String, Object> entry = json.parse(entryFile) as Map<String, Object>
+            return [name: entry.name as String, id: entry.id as Integer]
+        }
+
+        final Map<String, Map<String, Object>> entriesByName = entries.collectEntries { Map<String, Object> entry ->
+            [(entry.name): entry]
+        }
+        final Map<Integer, List<Map<String, Object>>> entriesById = entries.groupBy { Map<String, Object> entry ->
+            entry.id
+        }
+        final List<String> entryNames = entriesByName.keySet().sort { String first, String second ->
+            final int lengthOrder = second.length() <=> first.length()
+            return lengthOrder != 0 ? lengthOrder : first <=> second
+        }
+        final Map<Integer, List<String>> iconNamesById = entriesById.collectEntries { Integer id, List ignored ->
+            [(id): []]
+        }
+        final List<String> unassignedIcons = []
+
+        fileTree(xaeroPokemobIconSource) {
+            include '*.png'
+        }.files.sort { File first, File second -> first.name <=> second.name }.each { File iconFile ->
+            final String iconName = iconFile.name.substring(0, iconFile.name.length() - '.png'.length())
+            final String entryName = entryNames.find { String candidate ->
+                iconName.startsWith(candidate) || iconName.startsWith(candidate.replace('-', '_'))
+            }
+            if (entryName == null) unassignedIcons.add(iconName)
+            else iconNamesById[entriesByName[entryName].id].add(iconName)
+        }
+
+        if (!unassignedIcons.isEmpty()) {
+            throw new GradleException("Pokecube icons do not match a Pokedex entry: ${unassignedIcons.join(', ')}")
+        }
+
+        fileTree(xaeroPokemobIconSource) {
+            include '*.png'
+        }.files.each { File iconFile ->
+            final java.awt.image.BufferedImage source = javax.imageio.ImageIO.read(iconFile)
+            if (source == null) throw new GradleException("Could not read Pokecube icon ${iconFile}")
+
+            final java.awt.image.BufferedImage padded = new java.awt.image.BufferedImage(source.width * 2,
+                    source.height * 2, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+            final java.awt.Graphics2D graphics = padded.createGraphics()
+            try {
+                graphics.drawImage(source, source.width.intdiv(2), source.height.intdiv(2), null)
+            }
+            finally {
+                graphics.dispose()
+            }
+
+            if (!javax.imageio.ImageIO.write(padded, 'png', new File(spriteRoot, iconFile.name))) {
+                throw new GradleException("Could not write Xaero sprite for Pokecube icon ${iconFile}")
+            }
+        }
+
+        entries.each { Map<String, Object> entry ->
+            final List<Map<String, Object>> relatedEntries = entriesById[entry.id]
+            final List<String> iconNames = iconNamesById[entry.id].unique().sort()
+            final Map<String, String> variants = new TreeMap<>()
+            if (iconNames.isEmpty()) variants['default'] = 'dot'
+            else {
+                final def addVariant = { String iconKey, String sprite ->
+                    variants["pokecube_mobs:${iconKey}"] = sprite
+                    variants["pokecube:${iconKey}"] = sprite
+                }
+                iconNames.each { String iconName ->
+                    final String sprite = "normal_sprite:pokecube/${iconName}.png"
+                    addVariant(iconName, sprite)
+
+                    if (iconName.endsWith('s')) {
+                        final String normalName = iconName.substring(0, iconName.length() - 1)
+                        if (iconNames.contains(normalName)) addVariant("${normalName}_s", sprite)
+                    }
+
+                    relatedEntries.each { Map<String, Object> relatedEntry ->
+                        final String normalizedName = (relatedEntry.name as String).replace('-', '_')
+                        if (normalizedName != relatedEntry.name && iconName.startsWith(normalizedName)) {
+                            final String suffix = iconName.substring(normalizedName.length())
+                            addVariant("${relatedEntry.name}${suffix}", sprite)
+                        }
+                    }
+                }
+
+                final String defaultName = entry.name as String
+                final String normalizedDefaultName = defaultName.replace('-', '_')
+                final List<String> otherFormNames = relatedEntries.findAll { Map<String, Object> candidate ->
+                    candidate.name != defaultName
+                }.collectMany { Map<String, Object> candidate ->
+                    final String name = candidate.name as String
+                    return [name, name.replace('-', '_')]
+                }
+                final String defaultIcon = iconNames.find { String iconName -> iconName == defaultName }
+                        ?: iconNames.find { String iconName -> iconName == normalizedDefaultName }
+                        ?: iconNames.find { String iconName -> iconName == "${defaultName}_male" }
+                        ?: iconNames.find { String iconName -> iconName == "${normalizedDefaultName}_male" }
+                        ?: iconNames.find { String iconName -> iconName == "${defaultName}_female" }
+                        ?: iconNames.find { String iconName -> iconName == "${normalizedDefaultName}_female" }
+                        ?: iconNames.find { String iconName ->
+                            iconName.startsWith(defaultName) && !otherFormNames.any { iconName.startsWith(it) }
+                        }
+                        ?: iconNames.find { String iconName ->
+                            iconName.startsWith(normalizedDefaultName) && !otherFormNames.any { iconName.startsWith(it) }
+                        }
+                        ?: iconNames.first()
+                variants['default'] = "normal_sprite:pokecube/${defaultIcon}.png"
+            }
+
+            final Map<String, Object> definition = [
+                    variants     : variants,
+                    variantMethod: 'pokecube.compat.xaero.XaeroIconHandler.getVariant'
+            ]
+            final File outputFile = new File(definitionRoot, "${entry.name}.json")
+            outputFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(definition)) + System.lineSeparator()
+        }
+
+        final Map<String, Object> eggDefinition = [variants: [default: 'item:pokecube:pokemobegg']]
+        final File eggOutputFile = new File(definitionRoot, 'egg.json')
+        eggOutputFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(eggDefinition)) + System.lineSeparator()
+    }
+}
+
+sourceSets.main.resources { srcDir xaeroIconDefinitionOutput }
+
 //* Pokecube Legends
 sourceSets.main.resources { srcDir 'src/legends/resources' }
 sourceSets.main.java { srcDir 'src/legends/java' }
@@ -212,6 +356,8 @@ dependencies {
 // When "copyIdeResources" is enabled, this will also run before the game launches in IDE environments.
 // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
 tasks.withType(ProcessResources).configureEach {
+    dependsOn generateXaeroPokemobIconResources
+
     var replaceProperties = [
             minecraft_version      : minecraft_version,
             minecraft_version_range: minecraft_version_range,

--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,10 @@ sourceSets.main.java { srcDir 'src/pokecube/java' }
 sourceSets.main.resources { srcDir 'PokecubeMobs/pokecube_mobs' }
 //*/
 
+//* Configurable resource definitions
+sourceSets.main.resources { srcDir 'src/config/resources' }
+//*/
+
 //* Pokecube Adventures
 sourceSets.main.resources { srcDir 'src/adventures/resources' }
 sourceSets.main.java { srcDir 'src/adventures/java' }
@@ -163,6 +167,16 @@ def generateXaeroPokemobIconResources = tasks.register('generateXaeroPokemobIcon
     inputs.files(fileTree(xaeroPokedexEntrySource) { include '*.json' })
     inputs.files(fileTree(xaeroPokemobIconSource) { include '*.png' })
     outputs.dir(xaeroIconDefinitionOutput)
+
+    doFirst {
+        final def pokedexEntries = fileTree(xaeroPokedexEntrySource) { include '*.json' }.files
+        final def pokemobIcons = fileTree(xaeroPokemobIconSource) { include '*.png' }.files
+        if (pokedexEntries.isEmpty() || pokemobIcons.isEmpty()) {
+            throw new GradleException(
+                    'PokecubeMobs sources are missing or empty. Initialize the split source repository with ' +
+                            '`git submodule update --init --recursive` before building Pokecube AIO.')
+        }
+    }
 
     doLast {
         final File outputRoot = xaeroIconDefinitionOutput.get().asFile

--- a/src/compat/java/pokecube/compat/jei/ingredients/Pokemob.java
+++ b/src/compat/java/pokecube/compat/jei/ingredients/Pokemob.java
@@ -84,11 +84,12 @@ public class Pokemob implements IIngredientType<PokedexEntry>
             if (pokemob != null)
             {
                 final byte gender = pokemob.gender;
+                final FormeHolder holder = pokemob.holder == null ? pokemob.entry.getModel(gender) : pokemob.holder;
 //                Vector4f test = new Vector4f(1, 1, 1, 1);
 //                test.mul(graphics.pose().last().pose());
 //                int x = (int) test.x();
 //                int y = (int) test.y();
-                EventsHandlerClient.renderIcon(graphics, pokemob.entry, pokemob.holder, gender == IPokemob.FEMALE, 0, 0,
+                EventsHandlerClient.renderIcon(graphics, pokemob.entry, holder, gender == IPokemob.FEMALE, 0, 0,
                         16, 16, false);
             }
         }

--- a/src/compat/java/pokecube/compat/xaero/XaeroIconHandler.java
+++ b/src/compat/java/pokecube/compat/xaero/XaeroIconHandler.java
@@ -1,0 +1,37 @@
+package pokecube.compat.xaero;
+
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import pokecube.api.data.PokedexEntry;
+import pokecube.api.entity.pokemob.IPokemob;
+import pokecube.api.entity.pokemob.IPokemob.FormeHolder;
+import pokecube.api.entity.pokemob.PokemobCaps;
+
+@OnlyIn(Dist.CLIENT)
+public final class XaeroIconHandler
+{
+    private XaeroIconHandler()
+    {}
+
+    /**
+     * Selects the same icon variant used by Pokecube's own GUIs. Xaero calls this method reflectively when it builds
+     * an entity-radar icon, so this class does not require Xaero at compile time or runtime.
+     */
+    public static Object getVariant(final ResourceLocation texture, final EntityRenderer<?> renderer,
+            final Entity entity)
+    {
+        final IPokemob pokemob = PokemobCaps.getPokemobFor(entity);
+        if (pokemob == null) return texture;
+
+        final PokedexEntry entry = pokemob.getPokedexEntry();
+        if (entry == null) return texture;
+
+        final boolean male = pokemob.getSexe() != IPokemob.FEMALE;
+        final boolean shiny = pokemob.isShiny();
+        final FormeHolder holder = pokemob.getCustomHolder();
+        return holder == null ? entry.getIcon(male, shiny) : holder.getIcon(male, shiny, entry);
+    }
+}

--- a/src/config/resources/assets/pokecube_mobs/atlases/mob_icons.json
+++ b/src/config/resources/assets/pokecube_mobs/atlases/mob_icons.json
@@ -5,6 +5,7 @@
       "source": "entity_icon/pokemob",
       "prefix": ""
     },
+
     {
       "type": "single",
       "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_mod_male",

--- a/src/pokecube/java/pokecube/api/entity/pokemob/IPokemob.java
+++ b/src/pokecube/java/pokecube/api/entity/pokemob/IPokemob.java
@@ -116,7 +116,10 @@ public interface IPokemob
         {
             if (this.icons[0][0] == null)
             {
-                final String texture = this.key.toString();
+                ResourceLocation icon = this.key;
+                if (base != null && PokecubeCore.MODID.equals(icon.getNamespace()) && base.getModId() != null)
+                    icon = ResourceLocation.fromNamespaceAndPath(base.getModId(), icon.getPath());
+                final String texture = icon.toString();
                 this.icons[0][0] = ResourceLocation.parse(texture);
                 this.icons[0][1] = ResourceLocation.parse(texture + "_s");
                 this.icons[1][0] = ResourceLocation.parse(texture);

--- a/src/pokecube/java/pokecube/core/client/EventsHandlerClient.java
+++ b/src/pokecube/java/pokecube/core/client/EventsHandlerClient.java
@@ -11,6 +11,7 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
@@ -506,12 +507,71 @@ public class EventsHandlerClient
     public static void renderIcon(GuiGraphics guiGraphics, final PokedexEntry entry, final FormeHolder holder,
             final boolean female, int x, int y, final int width, final int height, final boolean shiny)
     {
-        ResourceLocation icon = entry.getIcon(!female, shiny);
-        if (holder != null) icon = holder.getIcon(!female, shiny, entry);
+        final boolean male = !female;
+        final List<ResourceLocation> icons = new ArrayList<>();
+        if (holder != null)
+        {
+            final ResourceLocation holderBase = holder.getIcon(male, false, entry);
+            EventsHandlerClient.addIconCandidate(icons, holder.getIcon(male, shiny, entry));
+            EventsHandlerClient.addFormeIconCandidates(icons, holderBase, male, shiny);
+        }
+        EventsHandlerClient.addIconCandidate(icons, entry.getIcon(male, shiny));
 
-        TextureAtlasSprite textureatlassprite = Minecraft.getInstance().getTextureAtlas(Resources.ICONS_MOB_SHEET)
-                .apply(icon);
+        final ResourceLocation entryBase = ResourceLocation.fromNamespaceAndPath(entry.getModId(),
+                entry.getTrimmedName());
+        EventsHandlerClient.addFormeIconCandidates(icons, entryBase, male, shiny);
+        EventsHandlerClient.addIconCandidate(icons, entryBase);
+
+        final var atlas = Minecraft.getInstance().getTextureAtlas(Resources.ICONS_MOB_SHEET);
+        final TextureAtlasSprite missing = atlas.apply(MissingTextureAtlasSprite.getLocation());
+        TextureAtlasSprite textureatlassprite = missing;
+        for (final ResourceLocation icon : icons)
+        {
+            final TextureAtlasSprite candidate = atlas.apply(icon);
+            if (candidate != missing)
+            {
+                textureatlassprite = candidate;
+                break;
+            }
+        }
         guiGraphics.blit(x, y, 0, width, height, textureatlassprite);
+    }
+
+    private static void addFormeIconCandidates(final List<ResourceLocation> icons, final ResourceLocation base,
+            final boolean male, final boolean shiny)
+    {
+        final String gender = male ? "_male" : "_female";
+        final String alternateGender = male ? "_female" : "_male";
+        if (shiny)
+        {
+            EventsHandlerClient.addIconCandidate(icons,
+                    ResourceLocation.fromNamespaceAndPath(base.getNamespace(), base.getPath() + "s"));
+            EventsHandlerClient.addIconCandidate(icons,
+                    ResourceLocation.fromNamespaceAndPath(base.getNamespace(), base.getPath() + gender + "s"));
+            EventsHandlerClient.addIconCandidate(icons,
+                    ResourceLocation.fromNamespaceAndPath(base.getNamespace(), base.getPath() + gender + "_s"));
+            EventsHandlerClient.addIconCandidate(icons,
+                    ResourceLocation.fromNamespaceAndPath(base.getNamespace(), base.getPath() + alternateGender + "s"));
+            EventsHandlerClient.addIconCandidate(icons, ResourceLocation.fromNamespaceAndPath(base.getNamespace(),
+                    base.getPath() + alternateGender + "_s"));
+        }
+        else
+        {
+            EventsHandlerClient.addIconCandidate(icons,
+                    ResourceLocation.fromNamespaceAndPath(base.getNamespace(), base.getPath() + gender));
+            EventsHandlerClient.addIconCandidate(icons, ResourceLocation.fromNamespaceAndPath(base.getNamespace(),
+                    base.getPath() + alternateGender));
+        }
+    }
+
+    private static void addIconCandidate(final List<ResourceLocation> icons, final ResourceLocation icon)
+    {
+        if (icon == null || icons.contains(icon)) return;
+        icons.add(icon);
+        final String normalized = icon.getPath().replace('-', '_');
+        if (!normalized.equals(icon.getPath()))
+            EventsHandlerClient.addIconCandidate(icons,
+                    ResourceLocation.fromNamespaceAndPath(icon.getNamespace(), normalized));
     }
 
     private static void setMostDamagingMove(final IPokemob outMob, final LivingEntity target)

--- a/src/pokecube/java/pokecube/core/client/gui/watch/PokemobInfoPage.java
+++ b/src/pokecube/java/pokecube/core/client/gui/watch/PokemobInfoPage.java
@@ -121,6 +121,32 @@ public class PokemobInfoPage extends PageWithSubPages<PokeInfoPage>
         this.pokemob = watch.pokemob;
     }
 
+    private static String getEntryDisplayName(final PokedexEntry entry)
+    {
+        final String name = I18n.get(entry.getUnlocalizedName());
+        final String baseName = entry.getBaseName();
+        String formeName = entry.getTrimmedName();
+        if (formeName.equals(baseName)) return name;
+        if (formeName.startsWith(baseName)) formeName = formeName.substring(baseName.length());
+        formeName = formeName.replace('_', ' ').replace('-', ' ').trim();
+        if (formeName.isEmpty()) return name;
+
+        final StringBuilder formatted = new StringBuilder();
+        for (final String part : formeName.split("\\s+"))
+        {
+            if (!formatted.isEmpty()) formatted.append(' ');
+            formatted.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+        }
+        return name + " (" + formatted + ")";
+    }
+
+    public void updateEntryField(final PokedexEntry entry)
+    {
+        this.searchBox.setValue(PokemobInfoPage.getEntryDisplayName(entry));
+        PacketPokedex.sendSpecificSpawnsRequest(entry);
+        PacketPokedex.updateWatchEntry(entry);
+    }
+
     @Override
     public boolean keyPressed(final int keyCode, final int b, final int c)
     {
@@ -158,21 +184,23 @@ public class PokemobInfoPage extends PageWithSubPages<PokeInfoPage>
             if (!ret.isEmpty()) this.searchBox.setValue(ret.get(0));
             return true;
         }
-            else if (keyCode == GLFW.GLFW_KEY_ENTER)
+        else if (keyCode == GLFW.GLFW_KEY_ENTER)
         {
             PokedexEntry entry = this.pokemob.getPokedexEntry();
             PokedexEntry newEntry = Database.getEntry(this.searchBox.getValue());
+            if (PokemobInfoPage.getEntryDisplayName(entry).equalsIgnoreCase(this.searchBox.getValue()))
+                newEntry = entry;
             // Search to see if maybe it was a translated name put into the
             // search.
             if (newEntry == null)
             {
                 for (final PokedexEntry e : Database.getSortedFormes())
                 {
-                    final String translated = I18n.get(e.getUnlocalizedName());
+                    final String translated = PokemobInfoPage.getEntryDisplayName(e);
                     if (translated.equalsIgnoreCase(this.searchBox.getValue()))
                     {
                         Database.data2.put(translated, e);
-                        entry = e;
+                        newEntry = e;
                         break;
                     }
                 }
@@ -240,9 +268,7 @@ public class PokemobInfoPage extends PageWithSubPages<PokeInfoPage>
         this.addRenderableWidget(this.searchBox);
         this.searchBox.setVisible(!this.watch.canEdit(pokemob));
         this.searchBox.setEditable(!this.watch.canEdit(pokemob));;
-        this.searchBox.setValue(I18n.get(entry.getUnlocalizedName()));
-        PacketPokedex.sendSpecificSpawnsRequest(entry);
-        PacketPokedex.updateWatchEntry(entry);
+        this.updateEntryField(entry);
         // Force close and open the page to update.
         this.changePage(this.index);
     }

--- a/src/pokecube/java/pokecube/core/client/gui/watch/pokemob/PokeInfoPage.java
+++ b/src/pokecube/java/pokecube/core/client/gui/watch/pokemob/PokeInfoPage.java
@@ -124,7 +124,7 @@ public abstract class PokeInfoPage extends WatchPage
             if (nextE == entry) nextE = Pokedex.getInstance().getFirstForm(entry);
             this.parent.pokemob.setPokedexEntry(nextE);
             this.parent.pokemob.setBasePokedexEntry(nextE);
-            this.parent.initPages(this.parent.pokemob);
+            this.parent.updateEntryField(nextE);
         }).bounds(x - 79, y + 40, 12, 12).setTexture(GuiPokeWatch.getWidgetTex())
         		.setRender(new UVImgRender(241, 72, 12, 12))
                 .createNarration(supplier -> Component.translatable("button.pokecube.pokewatch.forms.narrate")).build());

--- a/src/pokecube/java/pokecube/core/impl/capabilities/impl/PokemobGenes.java
+++ b/src/pokecube/java/pokecube/core/impl/capabilities/impl/PokemobGenes.java
@@ -380,6 +380,7 @@ public abstract class PokemobGenes extends PokemobSided implements IMobColourabl
         FormeHolder form = Database.formeHoldersByKey.getOrDefault(newEntry.getTrimmedName(),
                 newEntry.getModel(this.getSexe()));
         genesSpecies.getExpressed().getValue().setForme(form);
+        this.onGenesChanged();
         this.getGenes().markDirty();
     }
 
@@ -435,6 +436,7 @@ public abstract class PokemobGenes extends PokemobSided implements IMobColourabl
         Alleles<SpeciesInfo, SpeciesGene> genesSpecies = getGenes().getAlleles(GeneticsManager.SPECIESGENE);
         // Ensures the species gene is initialised
         genesSpecies.getExpressed().getValue().setForme(holder);
+        this.onGenesChanged();
         this.getGenes().markDirty();
     }
 

--- a/src/pokecube/resources/assets/pokecube_mobs/atlases/mob_icons.json
+++ b/src/pokecube/resources/assets/pokecube_mobs/atlases/mob_icons.json
@@ -4,6 +4,116 @@
       "type": "directory",
       "source": "entity_icon/pokemob",
       "prefix": ""
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_mod_male",
+      "sprite": "pokecube_mobs:vivillon_modern"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_savanna"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_de_male",
+      "sprite": "pokecube_mobs:vivillon_highplains"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_archipelago"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_continental"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_fancy"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_garden"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_jungle"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_marine"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_pokeball"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_river"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_tundra"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_el_male",
+      "sprite": "pokecube_mobs:vivillon_elegant"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_oc_male",
+      "sprite": "pokecube_mobs:vivillon_ocean"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_sa_male",
+      "sprite": "pokecube_mobs:vivillon_sandstorm"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_he_male",
+      "sprite": "pokecube_mobs:vivillon_hell"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_en_male",
+      "sprite": "pokecube_mobs:vivillon_end"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_po_male",
+      "sprite": "pokecube_mobs:vivillon_polar"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_ic_male",
+      "sprite": "pokecube_mobs:vivillon_icysnow"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_mon_male",
+      "sprite": "pokecube_mobs:vivillon_monsoon"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_su_male",
+      "sprite": "pokecube_mobs:vivillon_sun"
+    },
+    {
+      "type": "single",
+      "resource": "pokecube_mobs:entity_icon/pokemob/vivillon_male",
+      "sprite": "pokecube_mobs:vivillon_meadow"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add native Xaero entity-radar definitions generated from Pokécube's Pokédex entries and existing icon assets.
- Support Pokémob forms, gender and shiny variants, Pokémob eggs, and reduced-size radar icons.
- Resolve icon namespace and filename variations used by Pokécube and `pokecube_mobs`, including aliases for Vivillon's legacy abbreviated icon names.
- Use form model holders when rendering Pokémob ingredients in JEI.
- Invalidate cached textures when a Pokémob's form holder changes.
- Display the selected form in the Pokéwatch entry field without reopening the current page.

## Root cause

Xaero requires entity icon definitions and sprites that Pokécube did not provide. Some form-holder icon keys also resolved under the `pokecube` namespace even though the assets are supplied by `pokecube_mobs`, and existing icons use several gender, shiny, separator, and legacy naming conventions.

JEI did not fall back to an entry's model holder when no explicit holder was supplied. The Pokédex changed the form holder while retaining its previously cached texture, and generated forms translated only as their base species name.

## Validation

- Ran `.\gradlew.bat build --no-daemon`.
- Generated 1,254 Xaero definitions and 2,782 padded radar sprites.
- Tested with Pokécube, JEI, Xaero's Minimap, and Xaero's World Map on NeoForge 1.21.1.
- Verified trainer, Pokémob, and Pokémob egg icons in Xaero's entity radar.
- Verified affected JEI Pokémob entries.
- Verified all Vivillon forms in JEI and the Pokédex.
- Verified Pokédex form rendering and form labels with Vivillon and Hisuian Goodra.
