### PR TITLE
Fixed protect bugs, added encore messages, fixed swagger and rest, implemented heal pulse, implemented belly drum, set effect text to flavor text in moves if effect text could not be found

### DIFF
--- a/src/pokecube/java/pokecube/api/data/moves/Moves.java
+++ b/src/pokecube/java/pokecube/api/data/moves/Moves.java
@@ -37,6 +37,7 @@ public class Moves
         public float cooldown = 1.0f;
         public String effect_text_extend;
         public String effect_text_simple;
+        public String flavor_text; // Gen 9 moves have this instead of effect text.
         public int effect_chance;
         public String preset;
 
@@ -110,6 +111,7 @@ public class Moves
 
         public String _effect_text_extend = "";
         public String _effect_text_simple = "";
+        public String _flavor_text = ""; // Gen 9 moves have this instead of effect text.
 
         public String _sound_effect_source = null;
         public String _sound_effect_target = null;

--- a/src/pokecube/java/pokecube/api/data/moves/Parsers.java
+++ b/src/pokecube/java/pokecube/api/data/moves/Parsers.java
@@ -168,12 +168,6 @@ public class Parsers
             entry.root_entry._ohko = OHKO.stream()
                     .anyMatch(p -> Parsers.matches(entry.root_entry._effect_text_simple, p));
 
-            // If statement for extendability (e.g. if a healing move is created that heals 1/4th of the user's health)
-            if (entry.root_entry._effect_text_simple.contains("Heals the user") || entry.root_entry._effect_text_simple.contains("restores the user's hp"))
-            {
-                if (entry.root_entry._effect_text_simple.contains("half its max hp"))
-                    entry.root_entry._healing = 50;
-            }
             parseCategory(entry);
         }
     }
@@ -258,7 +252,7 @@ public class Parsers
         }
     }
 
-    // This class seems to do nothing but I cannot remove it as then the game cannot read swagger's type
+    // This class seems to do nothing but I cannot remove it as then the game cannot read swagger's type.
     public static class SwaggerParser extends BaseParser
     {
 

--- a/src/pokecube/java/pokecube/api/data/moves/Parsers.java
+++ b/src/pokecube/java/pokecube/api/data/moves/Parsers.java
@@ -37,7 +37,6 @@ public class Parsers
 
     static final List<Pattern> OHKO = Lists.newArrayList(Pattern.compile("(causes a one-hit ko.)"));
 
-    static final Pattern HEALOTHER = Pattern.compile("(restores the target's hp)");
 
     @Nullable
     static String getMatch(final String input, final Pattern pattern)
@@ -169,6 +168,12 @@ public class Parsers
             entry.root_entry._ohko = OHKO.stream()
                     .anyMatch(p -> Parsers.matches(entry.root_entry._effect_text_simple, p));
 
+            // If statement for extendability (e.g. if a healing move is created that heals 1/4th of the user's health)
+            if (entry.root_entry._effect_text_simple.contains("Heals the user") || entry.root_entry._effect_text_simple.contains("restores the user's hp"))
+            {
+                if (entry.root_entry._effect_text_simple.contains("half its max hp"))
+                    entry.root_entry._healing = 50;
+            }
             parseCategory(entry);
         }
     }
@@ -253,6 +258,7 @@ public class Parsers
         }
     }
 
+    // This class seems to do nothing but I cannot remove it as then the game cannot read swagger's type
     public static class SwaggerParser extends BaseParser
     {
 

--- a/src/pokecube/java/pokecube/api/moves/utils/IMoveConstants.java
+++ b/src/pokecube/java/pokecube/api/moves/utils/IMoveConstants.java
@@ -96,7 +96,7 @@ public interface IMoveConstants extends IMoveNames
     byte DRASTICALLY = 3;
 
     // Special Moves, ie ones needed for specific logic
-    // No move move for just sitting there
+    // No move for just sitting there
     String MOVE_NONE = "none";
 
     String DEFAULT_MOVE = "tackle";

--- a/src/pokecube/java/pokecube/api/moves/utils/MoveApplication.java
+++ b/src/pokecube/java/pokecube/api/moves/utils/MoveApplication.java
@@ -220,7 +220,7 @@ public class MoveApplication implements Comparable<MoveApplication>
 
             // Apply all of the scalings
             attackStrength *= efficiency * criticalRatio * terrainDamageModifier * stabRatio * superEffectScale;
-            // Here is the damage will will actually do.
+            // Here is what the damage will actually do.
             int finalAttackStrength = Math.max(0, Math.round(attackStrength));
 
             int beforeHealth = 0;

--- a/src/pokecube/java/pokecube/core/client/gui/components/OutMobInfo.java
+++ b/src/pokecube/java/pokecube/core/client/gui/components/OutMobInfo.java
@@ -7,6 +7,7 @@ import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.entity.LivingEntity;
 import pokecube.api.entity.pokemob.IPokemob;
 import pokecube.api.moves.MoveEntry;
+import pokecube.api.utils.PokeType;
 import pokecube.api.utils.Tools;
 import pokecube.core.PokecubeCore;
 import pokecube.core.client.GuiEvent;
@@ -200,7 +201,7 @@ public class OutMobInfo extends GuiEventComponent
                     }
                     // Finally draw the name
                     graphics.drawString(gui.getFont(), MovesUtils.getMoveName(move.getName(), pokemob).getString(),
-                            5 + movesOffsetX, moveIndex * 13 + movesOffsetY + 3 + h, move.getType(pokemob).colour);
+                            5 + movesOffsetX, moveIndex * 13 + movesOffsetY + 3 + h, (move.getType(pokemob) == null ? PokeType.unknown : move.getType(pokemob)).colour);
                 }
             }
 

--- a/src/pokecube/java/pokecube/core/database/moves/MovesDatabases.java
+++ b/src/pokecube/java/pokecube/core/database/moves/MovesDatabases.java
@@ -132,6 +132,15 @@ public class MovesDatabases
             holder.setMove(json);
             holder.animation = loadedAnimations.get(json.name);
 
+            if (json.effect_text_simple != null) { // Most moves
+                holder._effect_text_simple = json.effect_text_simple;
+            }
+            else if (json.flavor_text != null) { // If there is no effect text, use the flavor text to indicate what the move does.
+                holder._effect_text_simple = json.flavor_text;
+            }
+            else
+                PokecubeAPI.logInfo(json.name + " has neither effect text nor flavor text!");
+
             // Initialises preset/cleans up text.
             holder.preParse();
 

--- a/src/pokecube/java/pokecube/core/eventhandlers/MoveEventsHandler.java
+++ b/src/pokecube/java/pokecube/core/eventhandlers/MoveEventsHandler.java
@@ -354,35 +354,43 @@ public class MoveEventsHandler
         if (target != null && (ab = target.getAbility()) != null) ab.preMoveUse(target, move);
 
         if (attack.getName().equals(IMoveNames.MOVE_FALSESWIPE)) move.noFaint = true;
-        boolean blockMove = Tags.MOVE.isIn("block-moves", move.getName());
+        boolean blockMove = Tags.MOVE.isIn("block-moves", move.getName()); // If we are using a "block" move (e.g. protect)
+        boolean unblockable = Tags.MOVE.isIn("no-block-moves", move.getName()); // If we are using a move that goes through protect (e.g. phantom force)
 
-        if (!blockMove && target.getMoveStats().blocked && target.getMoveStats().blockTimer-- <= 0)
+        // Reset protect parameters if the target is set to block moves when they did not use protect
+        if (target.getLastMoveUsed() != null && target.getMoveStats().blocked && target.getMoveStats().blockTimer-- <= 0)
         {
-            MovesUtils.sendPairedMessages(attacker.getEntity(), target, "" + target.getMoveStats().BLOCKCOUNTER);
-            target.getMoveStats().blocked = false;
-            target.getMoveStats().blockTimer = 0;
-            target.getMoveStats().BLOCKCOUNTER = 0;
+            if (Tags.MOVE.isIn("block-moves", target.getLastMoveUsed()))
+            {
+                target.getMoveStats().blocked = false;
+                target.getMoveStats().blockTimer = 0;
+                target.getMoveStats().BLOCKCOUNTER = 0;
+            }
         }
-        boolean unblockable = Tags.MOVE.isIn("no-block-moves", move.getName());
-        if (attacker != target && !unblockable)
+
+        // Sets protect parameters if we are using protect and it has not already failed.
+        if (blockMove && attacker.getMoveStats().blockTimer != -1)
+        {
+            attacker.getMoveStats().blockTimer = PokecubeCore.getConfig().attackCooldown;
+            attacker.getMoveStats().blocked = true;
+            attacker.getMoveStats().BLOCKCOUNTER += 2;
+        }
+
+        // Perform protect checks if target is set to block moves and we are not using an unblockable move.
+        if (attacker != target && !unblockable && target.getMoveStats().blocked)
         {
             final float count = Math.max(0, target.getMoveStats().BLOCKCOUNTER - 2);
             final float chance = count != 0 ? Math.max(0.125f, 1 / count) : 1;
-            if (chance > Math.random()) {
+            if (chance > Math.random()) { // When the move is successful.
                 move.failed = true;
                 MovesUtils.sendPairedMessages(target.getEntity(), attacker, "pokemob.move.protect");
             }
-            else {
+            else { // When the move fails due to successive use.
+                target.getMoveStats().blocked = false;
+                target.getMoveStats().blockTimer = -1; // blockTimer is set to -1 to show protect has previously failed.
                 MovesUtils.sendPairedMessages(target.getEntity(), attacker, "pokemob.move.failed");
             }
         }
-        if (blockMove)
-        {
-            target.getMoveStats().blockTimer = PokecubeCore.getConfig().attackCooldown;
-            target.getMoveStats().blocked = true;
-            target.getMoveStats().BLOCKCOUNTER += 2;
-        }
-        if (target.getMoveStats().BLOCKCOUNTER > 0) target.getMoveStats().BLOCKCOUNTER--;
     }
 
     private static void onWorldAction(final MoveWorldAction.OnAction evt)

--- a/src/pokecube/java/pokecube/core/moves/MovesUtils.java
+++ b/src/pokecube/java/pokecube/core/moves/MovesUtils.java
@@ -405,7 +405,8 @@ public class MovesUtils implements IMoveConstants
         MutableComponent name = TComponent.translatable("pokemob.move." + attack);
         if (move != null)
         {
-            name.setStyle(name.getStyle().withColor(move.getType(user).colour));
+            // Ternary statement prevents a crash where game doesn't know what type the move is
+            name.setStyle(name.getStyle().withColor((move.getType(user) == null ? PokeType.unknown : move.getType(user)).colour));
         }
         return name;
     }

--- a/src/pokecube/java/pokecube/mobs/moves/attacks/BellyDrum.java
+++ b/src/pokecube/java/pokecube/mobs/moves/attacks/BellyDrum.java
@@ -1,0 +1,42 @@
+package pokecube.mobs.moves.attacks;
+
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import pokecube.api.data.moves.MoveProvider;
+import pokecube.api.entity.pokemob.IPokemob;
+import pokecube.api.entity.pokemob.PokemobCaps;
+import pokecube.api.moves.utils.IMoveConstants;
+import pokecube.api.moves.utils.MoveApplication;
+import pokecube.api.moves.utils.MoveApplication.Damage;
+import pokecube.api.moves.utils.MoveApplication.PostMoveUse;
+import pokecube.api.utils.PokeType;
+import pokecube.core.PokecubeCore;
+import pokecube.core.moves.MovesUtils;
+import pokecube.core.moves.damage.effects.StatusEffects;
+import thut.lib.TComponent;
+
+@MoveProvider(name = "belly-drum")
+public class BellyDrum implements PostMoveUse
+{
+    @Override
+    public void applyPostMove(Damage t) {
+        MoveApplication packet = t.move();
+        if (packet.canceled || packet.failed) return;
+
+        IPokemob attacker = packet.getUser();
+        final IPokemob target = PokemobCaps.getPokemobFor(packet.getTarget());
+
+        if (target != null)
+        {
+            if (attacker.getHealth() > (attacker.getMaxHealth() / 2.0f))
+            {
+                packet.stat_effects[IPokemob.Stats.ATTACK.ordinal()] = 6;
+
+                attacker.setHealth(attacker.getHealth() - (attacker.getMaxHealth() / 2.0f));
+                attacker.displayMessageToOwner(TComponent.translatable("pokemob.move.bellydrum.user", target.getDisplayName()));
+            }
+            else
+                attacker.displayMessageToOwner(TComponent.translatable("pokemob.move.failed.user", target.getDisplayName()));
+        }
+    }
+}

--- a/src/pokecube/java/pokecube/mobs/moves/attacks/Encore.java
+++ b/src/pokecube/java/pokecube/mobs/moves/attacks/Encore.java
@@ -34,13 +34,20 @@ public class Encore implements PostMoveUse
             final int timer = attacker.getEntity().getRandom().nextInt(7); // Same as Disable
 
             // (lastMoveIndex + 1) % targetMoves.length selects a move that is sure to not be the last move.
-            if (target.getDisableTimer((lastMoveIndex + 1) % targetMoves.length) <= 0 && timer > 0) { // Applies timer if the disabled moves are not yet disabled.
+            if (target.getDisableTimer((lastMoveIndex + 1) % targetMoves.length) <= 0 && timer > 0) // Applies timer if the disabled moves are not yet disabled.
+            {
+                MovesUtils.sendPairedMessages(target.getEntity(), attacker, "pokemob.move.encore.start");
                 for (int i = 0; i < targetMoves.length; i++) {
                     if (i != lastMoveIndex) target.setDisableTimer(lastMoveIndex, PokecubeCore.getConfig().attackCooldown * timer);
                 }
             }
+            else if (target.getDisableTimer((lastMoveIndex + 1) % targetMoves.length) <= 0) // Displays that encore has ended if the disable timer is zero.
+            {
+                MovesUtils.sendPairedMessages(target.getEntity(), attacker, "pokemob.move.encore.end");
+            }
 
             else MovesUtils.displayEfficiencyMessages(attacker, packet.getTarget(), -2, 0);
+
         }
     }
 }

--- a/src/pokecube/java/pokecube/mobs/moves/attacks/Rest.java
+++ b/src/pokecube/java/pokecube/mobs/moves/attacks/Rest.java
@@ -2,9 +2,11 @@ package pokecube.mobs.moves.attacks;
 
 import pokecube.api.data.moves.MoveProvider;
 import pokecube.api.entity.pokemob.IPokemob;
+import pokecube.api.entity.pokemob.PokemobCaps;
 import pokecube.api.moves.utils.MoveApplication;
 import pokecube.api.moves.utils.MoveApplication.Damage;
 import pokecube.api.moves.utils.MoveApplication.HealProvider;
+import pokecube.core.moves.MovesUtils;
 import pokecube.core.moves.damage.effects.StatusEffects;
 
 @MoveProvider(name = "rest")
@@ -15,9 +17,14 @@ public class Rest implements HealProvider
     {
         MoveApplication packet = t.move();
         if (packet.canceled || packet.failed) return;
+
         IPokemob attacker = packet.getUser();
+        IPokemob target = PokemobCaps.getPokemobFor(packet.getTarget());
+
         attacker.healStatus();
         attacker.healChanges();
+        attacker.getEntity().heal(attacker.getEntity().getMaxHealth() - attacker.getEntity().getHealth());
+        MovesUtils.sendPairedMessages(attacker.getEntity(), target, "pokemob.move.hprestore");
         StatusEffects.setStatus(attacker.getEntity(), attacker.getEntity(), StatusEffects.SLEEP, 2, 1);
     }
 }

--- a/src/pokecube/java/pokecube/mobs/moves/attacks/Swagger.java
+++ b/src/pokecube/java/pokecube/mobs/moves/attacks/Swagger.java
@@ -5,9 +5,11 @@ import net.minecraft.world.effect.MobEffects;
 import pokecube.api.data.moves.MoveProvider;
 import pokecube.api.entity.pokemob.IPokemob;
 import pokecube.api.entity.pokemob.PokemobCaps;
+import pokecube.api.moves.utils.IMoveConstants;
 import pokecube.api.moves.utils.MoveApplication;
 import pokecube.api.moves.utils.MoveApplication.Damage;
 import pokecube.api.moves.utils.MoveApplication.PostMoveUse;
+import pokecube.api.utils.PokeType;
 import pokecube.core.PokecubeCore;
 import pokecube.core.moves.MovesUtils;
 import pokecube.core.moves.damage.effects.StatusEffects;
@@ -26,7 +28,10 @@ public class Swagger implements PostMoveUse
         if (target != null)
         {
             packet.stat_effects[IPokemob.Stats.ATTACK.ordinal()] = 2;
-            target.getEntity().addEffect(new MobEffectInstance(MobEffects.CONFUSION, 200, 1));
+
+            MovesUtils.displayStatsMessage(attacker, packet.getTarget(), 0, 1, (byte)2);
+            StatusEffects.setStatus(packet.getTarget(), attacker.getEntity(), StatusEffects.CONFUSE, attacker.getEntity().getRandom().nextInt(2, 6), 1);
+            MovesUtils.displayStatusMessages(attacker, target.getEntity(), IMoveConstants.CHANGE_CONFUSED, false);
         }
     }
 }

--- a/src/pokecube/resources/assets/pokecube/lang/en_us.json
+++ b/src/pokecube/resources/assets/pokecube/lang/en_us.json
@@ -89,6 +89,9 @@
     "pokemob.move.missed.user": "§cIt missed§r %1$s!",
     "pokemob.move.missed.target": "§aIt missed§r %1$s!",
 
+    "pokemob.move.hprestore.user": "%1$s §c's HP was restored.",
+    "pokemob.move.hprestore.target": "%1$s §a's HP was restored.",
+
     "pokemob.move.protect.user": "%1$s §cprotected itself!",
     "pokemob.move.protect.target": "%1$s §aprotected itself!",
 

--- a/src/pokecube/resources/assets/pokecube/lang/en_us.json
+++ b/src/pokecube/resources/assets/pokecube/lang/en_us.json
@@ -92,6 +92,12 @@
     "pokemob.move.protect.user": "%1$s §cprotected itself!",
     "pokemob.move.protect.target": "%1$s §aprotected itself!",
 
+    "pokemob.move.encore.start.user": "%1$s §cmust do an encore!",
+    "pokemob.move.encore.start.target": "%1$s §amust do an encore",
+
+    "pokemob.move.encore.end.user": "%1$s §c's encore ended!",
+    "pokemob.move.encore.end.target": "%1$s §a's encore ended!",
+
     "pokemob.move.failed.user": "%1$s's §cattack failed!",
     "pokemob.move.failed.target": "%1$s's §aattack failed!",
 

--- a/src/pokecube/resources/assets/pokecube/lang/en_us.json
+++ b/src/pokecube/resources/assets/pokecube/lang/en_us.json
@@ -101,6 +101,9 @@
     "pokemob.move.encore.end.user": "%1$s §c's encore ended!",
     "pokemob.move.encore.end.target": "%1$s §a's encore ended!",
 
+    "pokemob.move.bellydrum.user": "%1$s §ccut its own HP and maximised attack!",
+    "pokemob.move.bellydrum.target": "%1$s §acut its own HP and maximised attack!",
+
     "pokemob.move.failed.user": "%1$s's §cattack failed!",
     "pokemob.move.failed.target": "%1$s's §aattack failed!",
 


### PR DESCRIPTION
Fixed all pokemobs using protect.
Fixed protect not failing after successive uses.
Fixed rest not healing.
Fixed swagger not doing anything.
Implemented heal pulse

Failed to fix the other healing moves that do not work (recover, milk drink, etc)

Added encore messages to en_us.json (still need to be added in pt_br.json and zh_ch.json) and displayed them in the battle log when encore starts and ends.

Added hp restore messages to en_us.json (still need to be added in pt_br.json and zh_ch.json) and displayed them when heal pulse lands on its target.