### PR TITLE
Add Mega Stone colour index and fix initial data sync

### DIFF
--- a/src/pokecube/java/pokecube/gimmicks/mega/MegaCapability.java
+++ b/src/pokecube/java/pokecube/gimmicks/mega/MegaCapability.java
@@ -129,6 +129,8 @@ public class MegaCapability implements IMegaCapability
     public static BiFunction<PokedexEntry, PokedexEntry, int[]> COLOUR_MAPPER = (base,mega)->{
         var custom = DEFAULT_COLOURERS.get(base);
         if(custom!=null) return custom.apply(mega);
+        var canonical = MegaStoneColours.get(mega);
+        if(canonical!=null) return canonical;
         return randomColor(base, mega);
     };
 

--- a/src/pokecube/java/pokecube/gimmicks/mega/MegaEvolveHelper.java
+++ b/src/pokecube/java/pokecube/gimmicks/mega/MegaEvolveHelper.java
@@ -87,6 +87,7 @@ public class MegaEvolveHelper
         // Init mega evo data, this will then load in mega evos when the
         // datapacks load during world load.
         MegaEvoData.init();
+        MegaStoneColours.init();
 
         PCContainer.CUSTOMPCWHILTELIST.add(stack -> stack.has(MEGA_WEARABLE)
                 && stack.get(MEGA_WEARABLE).withItem(stack).details().getEntry(stack) != null);

--- a/src/pokecube/java/pokecube/gimmicks/mega/MegaEvolveHelper.java
+++ b/src/pokecube/java/pokecube/gimmicks/mega/MegaEvolveHelper.java
@@ -145,7 +145,13 @@ public class MegaEvolveHelper
                         stone.entry = newEntry.getTrimmedName();
                         stone.colours = MegaCapability.COLOUR_MAPPER.apply(pokemob.getPokedexEntry(), newEntry);
                         stack.set(MEGA_STONE, stone);
-                        stack.set(DataComponents.CUSTOM_NAME, newEntry.getTranslatedName());
+                        final Component customName = stack.get(DataComponents.CUSTOM_NAME);
+                        if (customName == null || "Mega Stone".equalsIgnoreCase(customName.getString().trim()))
+                        {
+                            final String stoneName = MegaStoneColours.getName(newEntry);
+                            stack.set(DataComponents.CUSTOM_NAME,
+                                    stoneName == null ? newEntry.getTranslatedName() : Component.literal(stoneName));
+                        }
                         return handleChange(pokemob);
                     }
                 }

--- a/src/pokecube/java/pokecube/gimmicks/mega/MegaStoneColours.java
+++ b/src/pokecube/java/pokecube/gimmicks/mega/MegaStoneColours.java
@@ -1,148 +1,150 @@
 package pokecube.gimmicks.mega;
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import pokecube.api.PokecubeAPI;
 import pokecube.api.data.PokedexEntry;
+import pokecube.core.PokecubeCore;
+import pokecube.core.database.resources.PackFinder;
+import thut.api.data.DataHelpers;
+import thut.api.data.DataHelpers.ResourceData;
+import thut.api.util.JsonUtil;
+import thut.lib.ResourceHelper;
 
 /**
- * Canonical Pokemon Legends: Z-A names and tint colours for Mega Stones. The colour order matches the four item model
- * layers: outline, inner detail, secondary accent, and primary ring.
+ * Datapack-provided names and four-layer tint colours for Mega Stones. Files are loaded from
+ * {@code data/<namespace>/database/pokemobs/mega_stones/}. Resource stacks are applied from lowest to highest priority,
+ * so a datapack can override selected entries without copying the complete built-in index.
  */
-public final class MegaStoneColours
+public final class MegaStoneColours extends ResourceData
 {
-    private record Stone(String name, int outline, int detail, int secondary, int primary)
+    private record Stone(String name, int[] colours)
     {
         int[] toArray()
         {
-            return new int[] { this.outline, this.detail, this.secondary, this.primary };
+            return this.colours.clone();
         }
     }
 
-    /*
-     * Sampled from the common Pokemon Legends: Z-A bag-sprite layout at (100,80), (90,90), (90,80), and (110,80).
-     * This index supersedes the deprecated individual-item Mega Stone sprites.
-     */
-    private static final Map<String, Stone> STONES = Map.ofEntries(
-            Map.entry("abomasnow-mega", stone("Abomasite", 0xFFBAD7CF, 0xFF3C9CA7, 0xFFFDFDFD, 0xFF84AEDF)),
-            Map.entry("absol-mega", stone("Absolite", 0xFF698BB4, 0xFF315B91, 0xFFE6EEF1, 0xFFB3CDEA)),
-            Map.entry("aerodactyl-mega", stone("Aerodactylite", 0xFF5B166D, 0xFF6243A4, 0xFF47494B, 0xFFBAB2D3)),
-            Map.entry("aggron-mega", stone("Aggronite", 0xFF918E8F, 0xFFD1D1C7, 0xFF646163, 0xFFC8D4EE)),
-            Map.entry("alakazam-mega", stone("Alakazite", 0xFFCB92A0, 0xFFE4D967, 0xFF843553, 0xFFD2E1D1)),
-            Map.entry("altaria-mega", stone("Altarianite", 0xFF97E0FE, 0xFFE7E7E7, 0xFF69D5FF, 0xFFEDAADD)),
-            Map.entry("ampharos-mega", stone("Ampharosite", 0xFFFF6E6A, 0xFFFDDF4B, 0xFFED1A24, 0xFFB3CFEE)),
-            Map.entry("audino-mega", stone("Audinite", 0xFFE7A4A6, 0xFFFFF7D6, 0xFFEE6A8C, 0xFFFFDEE8)),
-            Map.entry("banette-mega", stone("Banettite", 0xFFF49A2F, 0xFF646263, 0xFFF7EC6E, 0xFFF6ADCC)),
-            Map.entry("beedrill-mega", stone("Beedrillite", 0xFFCCA208, 0xFF393939, 0xFFF8C719, 0xFFC4BCE6)),
-            Map.entry("blastoise-mega", stone("Blastoisinite", 0xFF44B2D1, 0xFF4B96CD, 0xFF624A28, 0xFFD3D2C7)),
-            Map.entry("blaziken-mega", stone("Blazikenite", 0xFF88280F, 0xFFEF2F2C, 0xFF221F20, 0xFFFDF1EC)),
-            Map.entry("camerupt-mega", stone("Cameruptite", 0xFFC65A48, 0xFF4B4A44, 0xFFEC7159, 0xFFBBAC9C)),
-            Map.entry("charizard-mega-x", stone("Charizardite X", 0xFF22618C, 0xFF484A4D, 0xFF45BDE8, 0xFF6EC2EC)),
-            Map.entry("charizard-mega-y", stone("Charizardite Y", 0xFFFE9A15, 0xFFED1A2E, 0xFFE6EC21, 0xFFF68648)),
-            Map.entry("diancie-mega", stone("Diancite", 0xFFE0B572, 0xFFE68AAB, 0xFFF9EFA5, 0xFFF4E4E5)),
-            Map.entry("gallade-mega", stone("Galladite", 0xFFDA99A2, 0xFF59A392, 0xFFDB6273, 0xFFEAEBD9)),
-            Map.entry("garchomp-mega", stone("Garchompite", 0xFFF78613, 0xFFEF2F2C, 0xFFFAB30A, 0xFF444868)),
-            Map.entry("gardevoir-mega", stone("Gardevoirite", 0xFFD93670, 0xFF94D87C, 0xFFF263AF, 0xFFB3CDEB)),
-            Map.entry("gengar-mega", stone("Gengarite", 0xFFC1144C, 0xFF493D61, 0xFFEA1F3B, 0xFFA3A9CF)),
-            Map.entry("glalie-mega", stone("Glalitite", 0xFF3A6070, 0xFF499ABA, 0xFF3B3B3A, 0xFFD4DAEC)),
-            Map.entry("gyarados-mega", stone("Gyaradosite", 0xFF821976, 0xFF3286CE, 0xFFD7144B, 0xFFCA922C)),
-            Map.entry("heracross-mega", stone("Heracronite", 0xFFEA1F3A, 0xFF27598F, 0xFFF38351, 0xFFF9DB3A)),
-            Map.entry("houndoom-mega", stone("Houndoominite", 0xFFBF1C2C, 0xFF303D39, 0xFFEB2034, 0xFFA25E7E)),
-            Map.entry("kangaskhan-mega", stone("Kangaskhanite", 0xFFA57F9F, 0xFFA3A9CE, 0xFF515758, 0xFFF8DE82)),
-            Map.entry("latias-mega", stone("Latiasite", 0xFFC6509B, 0xFF8B63D5, 0xFFFF3138, 0xFFBEC6FB)),
-            Map.entry("latios-mega", stone("Latiosite", 0xFF5E73EB, 0xFF8B63D6, 0xFF2884F7, 0xFFBDC6FC)),
-            Map.entry("lopunny-mega", stone("Lopunnite", 0xFF6A423C, 0xFFA16355, 0xFF493A3B, 0xFFF9F4BD)),
-            Map.entry("lucario-mega", stone("Lucarionite", 0xFF752763, 0xFF067891, 0xFFB00D2E, 0xFFF68536)),
-            Map.entry("manectric-mega", stone("Manectite", 0xFFA5185A, 0xFF4EB1CB, 0xFFEB1F33, 0xFFEDF588)),
-            Map.entry("mawile-mega", stone("Mawilite", 0xFFB47226, 0xFF4F4C4E, 0xFFF9ED9A, 0xFFF595CB)),
-            Map.entry("medicham-mega", stone("Medichamite", 0xFFEE702E, 0xFFEF3494, 0xFFF8E082, 0xFF6FC1ED)),
-            Map.entry("metagross-mega", stone("Metagrossite", 0xFFB7B3B9, 0xFFDA9B5B, 0xFFCCCCCC, 0xFF86BCD4)),
-            Map.entry("mewtwo-mega-x", stone("Mewtwonite X", 0xFF27588F, 0xFF8F6CA0, 0xFF2E82B2, 0xFFD1D1D2)),
-            Map.entry("mewtwo-mega-y", stone("Mewtwonite Y", 0xFFB479C2, 0xFF8F6CA0, 0xFFE2C2E6, 0xFFD1D1D2)),
-            Map.entry("pidgeot-mega", stone("Pidgeotite", 0xFFAF879D, 0xFFF7EF7C, 0xFFDD4173, 0xFFF79549)),
-            Map.entry("pinsir-mega", stone("Pinsirite", 0xFFB04427, 0xFFA1706A, 0xFFF06F39, 0xFFF8DC39)),
-            Map.entry("sableye-mega", stone("Sablenite", 0xFFAE4076, 0xFFE7285A, 0xFF795A9C, 0xFFFEDE7A)),
-            Map.entry("salamence-mega", stone("Salamencite", 0xFF2B728B, 0xFFE2595F, 0xFF2A92BA, 0xFFC4C5C6)),
-            Map.entry("sceptile-mega", stone("Sceptilite", 0xFF97734A, 0xFFDE6353, 0xFF274928, 0xFF74BC71)),
-            Map.entry("scizor-mega", stone("Scizorite", 0xFF432629, 0xFFEB1F3B, 0xFF222D3B, 0xFFC7ECF1)),
-            Map.entry("sharpedo-mega", stone("Sharpedonite", 0xFFCFC490, 0xFF3070A9, 0xFFFBDD81, 0xFFCDCCE5)),
-            Map.entry("slowbro-mega", stone("Slowbronite", 0xFFDBC188, 0xFFF4808C, 0xFFF3EE89, 0xFFBACDBC)),
-            Map.entry("steelix-mega", stone("Steelixite", 0xFFB3CADA, 0xFF3499E3, 0xFFCCECF4, 0xFF939AB3)),
-            Map.entry("swampert-mega", stone("Swampertite", 0xFFAE6A6C, 0xFFEF6A5B, 0xFF49535B, 0xFF72B4DB)),
-            Map.entry("tyranitar-mega", stone("Tyranitarite", 0xFF5E1F27, 0xFF1F1F26, 0xFFB3193E, 0xFFA0CA80)),
-            Map.entry("venusaur-mega", stone("Venusaurite", 0xFFDB346F, 0xFF1C7B74, 0xFFF364A8, 0xFF60B8CC)),
-            Map.entry("absol-mega-z", stone("Absolite Z", 0xFF111014, 0xFF2E6195, 0xFFDB015A, 0xFF00243C)),
-            Map.entry("barbaracle-mega", stone("Barbaracite", 0xFFFCFEFE, 0xFFCED1DE, 0xFFF57757, 0xFF2B3236)),
-            Map.entry("baxcalibur-mega", stone("Baxcalibrite", 0xFFBA3E41, 0xFF2F5E89, 0xFFB0A4E6, 0xFFC8EEEE)),
-            Map.entry("chandelure-mega", stone("Chandelurite", 0xFFD7B179, 0xFF302F30, 0xFFDDEEFA, 0xFF7447F9)),
-            Map.entry("chesnaught-mega", stone("Chesnaughtite", 0xFFD9B638, 0xFF467019, 0xFF87112C, 0xFFE9EADB)),
-            Map.entry("chimecho-mega", stone("Chimechite", 0xFF367799, 0xFFE54262, 0xFFBADDE9, 0xFFF4DB70)),
-            Map.entry("clefable-mega", stone("Clefablite", 0xFFFFFEFE, 0xFFFBE1D5, 0xFFE45386, 0xFFF78B9F)),
-            Map.entry("crabominable-mega", stone("Crabominite", 0xFFE7CE42, 0xFF4DC9EA, 0xFF585478, 0xFFFFFFFF)),
-            Map.entry("darkrai-mega", stone("Darkranite", 0xFF000000, 0xFFEDEDED, 0xFFFF22DC, 0xFF313031)),
-            Map.entry("delphox-mega", stone("Delphoxite", 0xFFFDFDF8, 0xFFE1523D, 0xFFFBE67B, 0xFF413146)),
-            Map.entry("dragalge-mega", stone("Dragalgite", 0xFF6D7A4D, 0xFF603731, 0xFFC65065, 0xFF996BE0)),
-            Map.entry("dragonite-mega", stone("Dragoninite", 0xFFE256C3, 0xFFF7F1D2, 0xFF2CA796, 0xFFEEBB6C)),
-            Map.entry("drampa-mega", stone("Drampanite", 0xFFE3ECDD, 0xFF3C4551, 0xFF1C916D, 0xFF67758E)),
-            Map.entry("eelektross-mega", stone("Eelektrossite", 0xFFDE726D, 0xFF1F5D74, 0xFFF4DF64, 0xFFFEFEFE)),
-            Map.entry("emboar-mega", stone("Emboarite", 0xFFD2794A, 0xFF454545, 0xFFE6C550, 0xFFDC5756)),
-            Map.entry("excadrill-mega", stone("Excadrite", 0xFFA25457, 0xFF5B4E4A, 0xFFF9624C, 0xFFBABDBD)),
-            Map.entry("falinks-mega", stone("Falinksite", 0xFF02A3FF, 0xFFE00200, 0xFF2D2927, 0xFFFFD302)),
-            Map.entry("feraligatr-mega", stone("Feraligite", 0xFF4C7188, 0xFFDB3B5C, 0xFFFBE1A5, 0xFF68BCE8)),
-            Map.entry("floette-eternal-mega", stone("Floettite", 0xFFFFFFFF, 0xFFDA0F3D, 0xFF3E5BA9, 0xFF383B3B)),
-            Map.entry("froslass-mega", stone("Froslassite", 0xFFDC7164, 0xFFFDFDFD, 0xFF8677DC, 0xFF8BC5E7)),
-            Map.entry("garchomp-mega-z", stone("Garchompite Z", 0xFFFDCE5B, 0xFFE73E0B, 0xFFFFFFFF, 0xFF484461)),
-            Map.entry("glimmora-mega", stone("Glimmoranite", 0xFF6E76DC, 0xFF4AD3C7, 0xFF1B368F, 0xFF2172EA)),
-            Map.entry("golisopod-mega", stone("Golisopite", 0xFFE7DE70, 0xFF873D99, 0xFF000000, 0xFF737A80)),
-            Map.entry("golurk-mega", stone("Golurkite", 0xFF007097, 0xFFEFD484, 0xFFA05BAC, 0xFF7CA8B0)),
-            Map.entry("greninja-mega", stone("Greninjite", 0xFFF4F1B5, 0xFF201F1F, 0xFFDE6E82, 0xFF68ACD6)),
-            Map.entry("hawlucha-mega", stone("Hawluchanite", 0xFF363634, 0xFF66B99A, 0xFFE7C252, 0xFFBF4131)),
-            Map.entry("heatran-mega", stone("Heatranite", 0xFFFFE200, 0xFFC9C9C9, 0xFFFFA801, 0xFFCF2C0E)),
-            Map.entry("lucario-mega-z", stone("Lucarionite Z", 0xFF5B5F64, 0xFF409CAA, 0xFFAEBDC2, 0xFFE3EB8A)),
-            Map.entry("magearna-mega", stone("Magearnite", 0xFFFFFFFF, 0xFFF9E27F, 0xFFFF98ED, 0xFFA91B2D)),
-            Map.entry("malamar-mega", stone("Malamarite", 0xFFEFE77F, 0xFFCD468A, 0xFF58EBF5, 0xFF787AA4)),
-            Map.entry("meganium-mega", stone("Meganiumite", 0xFFFFFFFF, 0xFFE14D52, 0xFFE97EA7, 0xFFC5FF9C)),
-            Map.entry("meowstic-mega", stone("Meowsticite", 0xFF7DCBDC, 0xFFFFFFFF, 0xFFFFCD00, 0xFF00528C)),
-            Map.entry("pyroar-mega", stone("Pyroarite", 0xFF2689AB, 0xFFF4E465, 0xFF5D504F, 0xFFCF192D)),
-            Map.entry("raichu-mega-x", stone("Raichunite X", 0xFFE40029, 0xFF393939, 0xFF8B4A2D, 0xFFFDDA00)),
-            Map.entry("raichu-mega-y", stone("Raichunite Y", 0xFF020000, 0xFFFEDB00, 0xFF5B452B, 0xFFF2A900)),
-            Map.entry("scolipede-mega", stone("Scolipite", 0xFF29E1B0, 0xFFAB599B, 0xFF474C4B, 0xFF897E90)),
-            Map.entry("scovillain-mega", stone("Scovillainite", 0xFF292A28, 0xFF406E50, 0xFFDF4F32, 0xFF5EAA5D)),
-            Map.entry("scrafty-mega", stone("Scraftinite", 0xFF5F5F62, 0xFFEC9E69, 0xFFDA5957, 0xFFEEECEE)),
-            Map.entry("skarmory-mega", stone("Skarmorite", 0xFF5D6F90, 0xFF3C4E6F, 0xFFEA3D2C, 0xFFE5C13B)),
-            Map.entry("staraptor-mega", stone("Staraptite", 0xFFFCAD04, 0xFFF96038, 0xFF574F48, 0xFFC7BEBD)),
-            Map.entry("starmie-mega", stone("Starminite", 0xFF3B71C1, 0xFFF7DB39, 0xFFBF1636, 0xFF7D79D1)),
-            Map.entry("tatsugiri-mega", stone("Tatsugirinite", 0xFFFF692B, 0xFFFFDE00, 0xFFFF497A, 0xFF00DE63)),
-            Map.entry("victreebel-mega", stone("Victreebelite", 0xFFDC9AA4, 0xFF9AC45C, 0xFFF89669, 0xFFE6DD55)),
-            Map.entry("zeraora-mega", stone("Zeraorite", 0xFF6F7176, 0xFFEEDB5A, 0xFF80C5E6, 0xFF363835)),
-            Map.entry("zygarde-mega", stone("Zygardite", 0xFF346DC5, 0xFF8BE044, 0xFFD02228, 0xFF504A41)));
-
-    private MegaStoneColours()
+    private static class StoneDefinition
     {
+        String name;
+        List<String> colours = Collections.emptyList();
+
+        Stone parse(final String entry)
+        {
+            if (this.name == null || this.name.isBlank())
+                throw new IllegalArgumentException("Missing Mega Stone name for " + entry);
+            if (this.colours == null || this.colours.size() != 4)
+                throw new IllegalArgumentException("Mega Stone " + entry + " must define exactly four colours");
+            final int[] parsed = new int[4];
+            for (int i = 0; i < parsed.length; i++) parsed[i] = MegaStoneColours.parseColour(this.colours.get(i));
+            return new Stone(this.name, parsed);
+        }
     }
 
-    private static Stone stone(final String name, final int outline, final int detail, final int secondary,
-            final int primary)
+    private static class StoneFile
     {
-        return new Stone(name, outline, detail, secondary, primary);
+        boolean replace = false;
+        Map<String, StoneDefinition> values = Collections.emptyMap();
+    }
+
+    public static final MegaStoneColours INSTANCE = new MegaStoneColours(
+            "database/pokemobs/mega_stones/");
+
+    private static volatile Map<String, Stone> stones = Collections.emptyMap();
+
+    private final String path;
+
+    private MegaStoneColours(final String path)
+    {
+        super(path);
+        this.path = ResourceLocation.parse(path).getPath();
+        DataHelpers.addDataType(this);
+    }
+
+    /** Forces this datapack loader to be registered during Mega Evolution setup. */
+    public static void init()
+    {}
+
+    @Override
+    public void reload(final AtomicBoolean valid)
+    {
+        final Map<String, Stone> loaded = new HashMap<>();
+        final Map<ResourceLocation, List<Resource>> resources = PackFinder.getAllJsonResources(this.path);
+        this.preLoad();
+        resources.forEach((location, stack) -> stack.forEach(resource -> this.loadFile(location, resource, loaded)));
+        stones = Map.copyOf(loaded);
+        if (!loaded.isEmpty())
+        {
+            if (PokecubeCore.getConfig().debug_data)
+                PokecubeAPI.logInfo("Loaded {} Mega Stone colour definitions.", loaded.size());
+            valid.set(true);
+        }
+    }
+
+    private void loadFile(final ResourceLocation location, final Resource resource, final Map<String, Stone> loaded)
+    {
+        try (BufferedReader reader = ResourceHelper.getReader(resource))
+        {
+            if (reader == null) throw new FileNotFoundException(location.toString());
+            final StoneFile file = JsonUtil.gson.fromJson(reader, StoneFile.class);
+            if (file == null || file.values == null)
+                throw new IllegalArgumentException("Missing Mega Stone values in " + location);
+            if (file.replace) loaded.clear();
+            file.values.forEach((entry, definition) -> {
+                try
+                {
+                    loaded.put(entry, definition.parse(entry));
+                }
+                catch (final Exception e)
+                {
+                    PokecubeAPI.LOGGER.error("Invalid Mega Stone definition {} in {}", entry, location, e);
+                }
+            });
+        }
+        catch (final Exception e)
+        {
+            PokecubeAPI.LOGGER.error("Error loading Mega Stone definitions from {}", location, e);
+        }
+    }
+
+    private static int parseColour(final String value)
+    {
+        if (value == null) throw new IllegalArgumentException("Missing colour");
+        String hex = value.trim();
+        if (hex.startsWith("#")) hex = hex.substring(1);
+        else if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
+        if (hex.length() == 6) hex = "FF" + hex;
+        if (hex.length() != 8) throw new IllegalArgumentException("Expected #RRGGBB or #AARRGGBB, got " + value);
+        return (int) Long.parseUnsignedLong(hex, 16);
     }
 
     /**
-     * @return the canonical Pokemon Legends: Z-A name for the Mega Stone, or {@code null} when no stone is known
+     * @return the datapack-provided name for the Mega Stone, or {@code null} when no stone is known
      */
     public static String getName(final PokedexEntry mega)
     {
         if (mega == null) return null;
-        final Stone stone = STONES.get(mega.getTrimmedName());
+        final Stone stone = stones.get(mega.getTrimmedName());
         return stone == null ? null : stone.name();
     }
 
     /**
-     * @return a new four-colour array for the Mega entry, or {@code null} when no canonical stone is known
+     * @return a new four-colour array for the Mega entry, or {@code null} when no stone is known
      */
     public static int[] get(final PokedexEntry mega)
     {
         if (mega == null) return null;
-        final Stone stone = STONES.get(mega.getTrimmedName());
+        final Stone stone = stones.get(mega.getTrimmedName());
         return stone == null ? null : stone.toArray();
     }
 }

--- a/src/pokecube/java/pokecube/gimmicks/mega/MegaStoneColours.java
+++ b/src/pokecube/java/pokecube/gimmicks/mega/MegaStoneColours.java
@@ -1,0 +1,148 @@
+package pokecube.gimmicks.mega;
+
+import java.util.Map;
+
+import pokecube.api.data.PokedexEntry;
+
+/**
+ * Canonical Pokemon Legends: Z-A names and tint colours for Mega Stones. The colour order matches the four item model
+ * layers: outline, inner detail, secondary accent, and primary ring.
+ */
+public final class MegaStoneColours
+{
+    private record Stone(String name, int outline, int detail, int secondary, int primary)
+    {
+        int[] toArray()
+        {
+            return new int[] { this.outline, this.detail, this.secondary, this.primary };
+        }
+    }
+
+    /*
+     * Sampled from the common Pokemon Legends: Z-A bag-sprite layout at (100,80), (90,90), (90,80), and (110,80).
+     * This index supersedes the deprecated individual-item Mega Stone sprites.
+     */
+    private static final Map<String, Stone> STONES = Map.ofEntries(
+            Map.entry("abomasnow-mega", stone("Abomasite", 0xFFBAD7CF, 0xFF3C9CA7, 0xFFFDFDFD, 0xFF84AEDF)),
+            Map.entry("absol-mega", stone("Absolite", 0xFF698BB4, 0xFF315B91, 0xFFE6EEF1, 0xFFB3CDEA)),
+            Map.entry("aerodactyl-mega", stone("Aerodactylite", 0xFF5B166D, 0xFF6243A4, 0xFF47494B, 0xFFBAB2D3)),
+            Map.entry("aggron-mega", stone("Aggronite", 0xFF918E8F, 0xFFD1D1C7, 0xFF646163, 0xFFC8D4EE)),
+            Map.entry("alakazam-mega", stone("Alakazite", 0xFFCB92A0, 0xFFE4D967, 0xFF843553, 0xFFD2E1D1)),
+            Map.entry("altaria-mega", stone("Altarianite", 0xFF97E0FE, 0xFFE7E7E7, 0xFF69D5FF, 0xFFEDAADD)),
+            Map.entry("ampharos-mega", stone("Ampharosite", 0xFFFF6E6A, 0xFFFDDF4B, 0xFFED1A24, 0xFFB3CFEE)),
+            Map.entry("audino-mega", stone("Audinite", 0xFFE7A4A6, 0xFFFFF7D6, 0xFFEE6A8C, 0xFFFFDEE8)),
+            Map.entry("banette-mega", stone("Banettite", 0xFFF49A2F, 0xFF646263, 0xFFF7EC6E, 0xFFF6ADCC)),
+            Map.entry("beedrill-mega", stone("Beedrillite", 0xFFCCA208, 0xFF393939, 0xFFF8C719, 0xFFC4BCE6)),
+            Map.entry("blastoise-mega", stone("Blastoisinite", 0xFF44B2D1, 0xFF4B96CD, 0xFF624A28, 0xFFD3D2C7)),
+            Map.entry("blaziken-mega", stone("Blazikenite", 0xFF88280F, 0xFFEF2F2C, 0xFF221F20, 0xFFFDF1EC)),
+            Map.entry("camerupt-mega", stone("Cameruptite", 0xFFC65A48, 0xFF4B4A44, 0xFFEC7159, 0xFFBBAC9C)),
+            Map.entry("charizard-mega-x", stone("Charizardite X", 0xFF22618C, 0xFF484A4D, 0xFF45BDE8, 0xFF6EC2EC)),
+            Map.entry("charizard-mega-y", stone("Charizardite Y", 0xFFFE9A15, 0xFFED1A2E, 0xFFE6EC21, 0xFFF68648)),
+            Map.entry("diancie-mega", stone("Diancite", 0xFFE0B572, 0xFFE68AAB, 0xFFF9EFA5, 0xFFF4E4E5)),
+            Map.entry("gallade-mega", stone("Galladite", 0xFFDA99A2, 0xFF59A392, 0xFFDB6273, 0xFFEAEBD9)),
+            Map.entry("garchomp-mega", stone("Garchompite", 0xFFF78613, 0xFFEF2F2C, 0xFFFAB30A, 0xFF444868)),
+            Map.entry("gardevoir-mega", stone("Gardevoirite", 0xFFD93670, 0xFF94D87C, 0xFFF263AF, 0xFFB3CDEB)),
+            Map.entry("gengar-mega", stone("Gengarite", 0xFFC1144C, 0xFF493D61, 0xFFEA1F3B, 0xFFA3A9CF)),
+            Map.entry("glalie-mega", stone("Glalitite", 0xFF3A6070, 0xFF499ABA, 0xFF3B3B3A, 0xFFD4DAEC)),
+            Map.entry("gyarados-mega", stone("Gyaradosite", 0xFF821976, 0xFF3286CE, 0xFFD7144B, 0xFFCA922C)),
+            Map.entry("heracross-mega", stone("Heracronite", 0xFFEA1F3A, 0xFF27598F, 0xFFF38351, 0xFFF9DB3A)),
+            Map.entry("houndoom-mega", stone("Houndoominite", 0xFFBF1C2C, 0xFF303D39, 0xFFEB2034, 0xFFA25E7E)),
+            Map.entry("kangaskhan-mega", stone("Kangaskhanite", 0xFFA57F9F, 0xFFA3A9CE, 0xFF515758, 0xFFF8DE82)),
+            Map.entry("latias-mega", stone("Latiasite", 0xFFC6509B, 0xFF8B63D5, 0xFFFF3138, 0xFFBEC6FB)),
+            Map.entry("latios-mega", stone("Latiosite", 0xFF5E73EB, 0xFF8B63D6, 0xFF2884F7, 0xFFBDC6FC)),
+            Map.entry("lopunny-mega", stone("Lopunnite", 0xFF6A423C, 0xFFA16355, 0xFF493A3B, 0xFFF9F4BD)),
+            Map.entry("lucario-mega", stone("Lucarionite", 0xFF752763, 0xFF067891, 0xFFB00D2E, 0xFFF68536)),
+            Map.entry("manectric-mega", stone("Manectite", 0xFFA5185A, 0xFF4EB1CB, 0xFFEB1F33, 0xFFEDF588)),
+            Map.entry("mawile-mega", stone("Mawilite", 0xFFB47226, 0xFF4F4C4E, 0xFFF9ED9A, 0xFFF595CB)),
+            Map.entry("medicham-mega", stone("Medichamite", 0xFFEE702E, 0xFFEF3494, 0xFFF8E082, 0xFF6FC1ED)),
+            Map.entry("metagross-mega", stone("Metagrossite", 0xFFB7B3B9, 0xFFDA9B5B, 0xFFCCCCCC, 0xFF86BCD4)),
+            Map.entry("mewtwo-mega-x", stone("Mewtwonite X", 0xFF27588F, 0xFF8F6CA0, 0xFF2E82B2, 0xFFD1D1D2)),
+            Map.entry("mewtwo-mega-y", stone("Mewtwonite Y", 0xFFB479C2, 0xFF8F6CA0, 0xFFE2C2E6, 0xFFD1D1D2)),
+            Map.entry("pidgeot-mega", stone("Pidgeotite", 0xFFAF879D, 0xFFF7EF7C, 0xFFDD4173, 0xFFF79549)),
+            Map.entry("pinsir-mega", stone("Pinsirite", 0xFFB04427, 0xFFA1706A, 0xFFF06F39, 0xFFF8DC39)),
+            Map.entry("sableye-mega", stone("Sablenite", 0xFFAE4076, 0xFFE7285A, 0xFF795A9C, 0xFFFEDE7A)),
+            Map.entry("salamence-mega", stone("Salamencite", 0xFF2B728B, 0xFFE2595F, 0xFF2A92BA, 0xFFC4C5C6)),
+            Map.entry("sceptile-mega", stone("Sceptilite", 0xFF97734A, 0xFFDE6353, 0xFF274928, 0xFF74BC71)),
+            Map.entry("scizor-mega", stone("Scizorite", 0xFF432629, 0xFFEB1F3B, 0xFF222D3B, 0xFFC7ECF1)),
+            Map.entry("sharpedo-mega", stone("Sharpedonite", 0xFFCFC490, 0xFF3070A9, 0xFFFBDD81, 0xFFCDCCE5)),
+            Map.entry("slowbro-mega", stone("Slowbronite", 0xFFDBC188, 0xFFF4808C, 0xFFF3EE89, 0xFFBACDBC)),
+            Map.entry("steelix-mega", stone("Steelixite", 0xFFB3CADA, 0xFF3499E3, 0xFFCCECF4, 0xFF939AB3)),
+            Map.entry("swampert-mega", stone("Swampertite", 0xFFAE6A6C, 0xFFEF6A5B, 0xFF49535B, 0xFF72B4DB)),
+            Map.entry("tyranitar-mega", stone("Tyranitarite", 0xFF5E1F27, 0xFF1F1F26, 0xFFB3193E, 0xFFA0CA80)),
+            Map.entry("venusaur-mega", stone("Venusaurite", 0xFFDB346F, 0xFF1C7B74, 0xFFF364A8, 0xFF60B8CC)),
+            Map.entry("absol-mega-z", stone("Absolite Z", 0xFF111014, 0xFF2E6195, 0xFFDB015A, 0xFF00243C)),
+            Map.entry("barbaracle-mega", stone("Barbaracite", 0xFFFCFEFE, 0xFFCED1DE, 0xFFF57757, 0xFF2B3236)),
+            Map.entry("baxcalibur-mega", stone("Baxcalibrite", 0xFFBA3E41, 0xFF2F5E89, 0xFFB0A4E6, 0xFFC8EEEE)),
+            Map.entry("chandelure-mega", stone("Chandelurite", 0xFFD7B179, 0xFF302F30, 0xFFDDEEFA, 0xFF7447F9)),
+            Map.entry("chesnaught-mega", stone("Chesnaughtite", 0xFFD9B638, 0xFF467019, 0xFF87112C, 0xFFE9EADB)),
+            Map.entry("chimecho-mega", stone("Chimechite", 0xFF367799, 0xFFE54262, 0xFFBADDE9, 0xFFF4DB70)),
+            Map.entry("clefable-mega", stone("Clefablite", 0xFFFFFEFE, 0xFFFBE1D5, 0xFFE45386, 0xFFF78B9F)),
+            Map.entry("crabominable-mega", stone("Crabominite", 0xFFE7CE42, 0xFF4DC9EA, 0xFF585478, 0xFFFFFFFF)),
+            Map.entry("darkrai-mega", stone("Darkranite", 0xFF000000, 0xFFEDEDED, 0xFFFF22DC, 0xFF313031)),
+            Map.entry("delphox-mega", stone("Delphoxite", 0xFFFDFDF8, 0xFFE1523D, 0xFFFBE67B, 0xFF413146)),
+            Map.entry("dragalge-mega", stone("Dragalgite", 0xFF6D7A4D, 0xFF603731, 0xFFC65065, 0xFF996BE0)),
+            Map.entry("dragonite-mega", stone("Dragoninite", 0xFFE256C3, 0xFFF7F1D2, 0xFF2CA796, 0xFFEEBB6C)),
+            Map.entry("drampa-mega", stone("Drampanite", 0xFFE3ECDD, 0xFF3C4551, 0xFF1C916D, 0xFF67758E)),
+            Map.entry("eelektross-mega", stone("Eelektrossite", 0xFFDE726D, 0xFF1F5D74, 0xFFF4DF64, 0xFFFEFEFE)),
+            Map.entry("emboar-mega", stone("Emboarite", 0xFFD2794A, 0xFF454545, 0xFFE6C550, 0xFFDC5756)),
+            Map.entry("excadrill-mega", stone("Excadrite", 0xFFA25457, 0xFF5B4E4A, 0xFFF9624C, 0xFFBABDBD)),
+            Map.entry("falinks-mega", stone("Falinksite", 0xFF02A3FF, 0xFFE00200, 0xFF2D2927, 0xFFFFD302)),
+            Map.entry("feraligatr-mega", stone("Feraligite", 0xFF4C7188, 0xFFDB3B5C, 0xFFFBE1A5, 0xFF68BCE8)),
+            Map.entry("floette-eternal-mega", stone("Floettite", 0xFFFFFFFF, 0xFFDA0F3D, 0xFF3E5BA9, 0xFF383B3B)),
+            Map.entry("froslass-mega", stone("Froslassite", 0xFFDC7164, 0xFFFDFDFD, 0xFF8677DC, 0xFF8BC5E7)),
+            Map.entry("garchomp-mega-z", stone("Garchompite Z", 0xFFFDCE5B, 0xFFE73E0B, 0xFFFFFFFF, 0xFF484461)),
+            Map.entry("glimmora-mega", stone("Glimmoranite", 0xFF6E76DC, 0xFF4AD3C7, 0xFF1B368F, 0xFF2172EA)),
+            Map.entry("golisopod-mega", stone("Golisopite", 0xFFE7DE70, 0xFF873D99, 0xFF000000, 0xFF737A80)),
+            Map.entry("golurk-mega", stone("Golurkite", 0xFF007097, 0xFFEFD484, 0xFFA05BAC, 0xFF7CA8B0)),
+            Map.entry("greninja-mega", stone("Greninjite", 0xFFF4F1B5, 0xFF201F1F, 0xFFDE6E82, 0xFF68ACD6)),
+            Map.entry("hawlucha-mega", stone("Hawluchanite", 0xFF363634, 0xFF66B99A, 0xFFE7C252, 0xFFBF4131)),
+            Map.entry("heatran-mega", stone("Heatranite", 0xFFFFE200, 0xFFC9C9C9, 0xFFFFA801, 0xFFCF2C0E)),
+            Map.entry("lucario-mega-z", stone("Lucarionite Z", 0xFF5B5F64, 0xFF409CAA, 0xFFAEBDC2, 0xFFE3EB8A)),
+            Map.entry("magearna-mega", stone("Magearnite", 0xFFFFFFFF, 0xFFF9E27F, 0xFFFF98ED, 0xFFA91B2D)),
+            Map.entry("malamar-mega", stone("Malamarite", 0xFFEFE77F, 0xFFCD468A, 0xFF58EBF5, 0xFF787AA4)),
+            Map.entry("meganium-mega", stone("Meganiumite", 0xFFFFFFFF, 0xFFE14D52, 0xFFE97EA7, 0xFFC5FF9C)),
+            Map.entry("meowstic-mega", stone("Meowsticite", 0xFF7DCBDC, 0xFFFFFFFF, 0xFFFFCD00, 0xFF00528C)),
+            Map.entry("pyroar-mega", stone("Pyroarite", 0xFF2689AB, 0xFFF4E465, 0xFF5D504F, 0xFFCF192D)),
+            Map.entry("raichu-mega-x", stone("Raichunite X", 0xFFE40029, 0xFF393939, 0xFF8B4A2D, 0xFFFDDA00)),
+            Map.entry("raichu-mega-y", stone("Raichunite Y", 0xFF020000, 0xFFFEDB00, 0xFF5B452B, 0xFFF2A900)),
+            Map.entry("scolipede-mega", stone("Scolipite", 0xFF29E1B0, 0xFFAB599B, 0xFF474C4B, 0xFF897E90)),
+            Map.entry("scovillain-mega", stone("Scovillainite", 0xFF292A28, 0xFF406E50, 0xFFDF4F32, 0xFF5EAA5D)),
+            Map.entry("scrafty-mega", stone("Scraftinite", 0xFF5F5F62, 0xFFEC9E69, 0xFFDA5957, 0xFFEEECEE)),
+            Map.entry("skarmory-mega", stone("Skarmorite", 0xFF5D6F90, 0xFF3C4E6F, 0xFFEA3D2C, 0xFFE5C13B)),
+            Map.entry("staraptor-mega", stone("Staraptite", 0xFFFCAD04, 0xFFF96038, 0xFF574F48, 0xFFC7BEBD)),
+            Map.entry("starmie-mega", stone("Starminite", 0xFF3B71C1, 0xFFF7DB39, 0xFFBF1636, 0xFF7D79D1)),
+            Map.entry("tatsugiri-mega", stone("Tatsugirinite", 0xFFFF692B, 0xFFFFDE00, 0xFFFF497A, 0xFF00DE63)),
+            Map.entry("victreebel-mega", stone("Victreebelite", 0xFFDC9AA4, 0xFF9AC45C, 0xFFF89669, 0xFFE6DD55)),
+            Map.entry("zeraora-mega", stone("Zeraorite", 0xFF6F7176, 0xFFEEDB5A, 0xFF80C5E6, 0xFF363835)),
+            Map.entry("zygarde-mega", stone("Zygardite", 0xFF346DC5, 0xFF8BE044, 0xFFD02228, 0xFF504A41)));
+
+    private MegaStoneColours()
+    {
+    }
+
+    private static Stone stone(final String name, final int outline, final int detail, final int secondary,
+            final int primary)
+    {
+        return new Stone(name, outline, detail, secondary, primary);
+    }
+
+    /**
+     * @return the canonical Pokemon Legends: Z-A name for the Mega Stone, or {@code null} when no stone is known
+     */
+    public static String getName(final PokedexEntry mega)
+    {
+        if (mega == null) return null;
+        final Stone stone = STONES.get(mega.getTrimmedName());
+        return stone == null ? null : stone.name();
+    }
+
+    /**
+     * @return a new four-colour array for the Mega entry, or {@code null} when no canonical stone is known
+     */
+    public static int[] get(final PokedexEntry mega)
+    {
+        if (mega == null) return null;
+        final Stone stone = STONES.get(mega.getTrimmedName());
+        return stone == null ? null : stone.toArray();
+    }
+}

--- a/src/pokecube/resources/data/pokecube/database/pokemobs/mega_stones/legends_za.json
+++ b/src/pokecube/resources/data/pokecube/database/pokemobs/mega_stones/legends_za.json
@@ -1,0 +1,373 @@
+{
+  "replace": false,
+  "values": {
+    "abomasnow-mega": {
+      "name": "Abomasite",
+      "colours": ["#FFBAD7CF", "#FF3C9CA7", "#FFFDFDFD", "#FF84AEDF"]
+    },
+    "absol-mega": {
+      "name": "Absolite",
+      "colours": ["#FF698BB4", "#FF315B91", "#FFE6EEF1", "#FFB3CDEA"]
+    },
+    "aerodactyl-mega": {
+      "name": "Aerodactylite",
+      "colours": ["#FF5B166D", "#FF6243A4", "#FF47494B", "#FFBAB2D3"]
+    },
+    "aggron-mega": {
+      "name": "Aggronite",
+      "colours": ["#FF918E8F", "#FFD1D1C7", "#FF646163", "#FFC8D4EE"]
+    },
+    "alakazam-mega": {
+      "name": "Alakazite",
+      "colours": ["#FFCB92A0", "#FFE4D967", "#FF843553", "#FFD2E1D1"]
+    },
+    "altaria-mega": {
+      "name": "Altarianite",
+      "colours": ["#FF97E0FE", "#FFE7E7E7", "#FF69D5FF", "#FFEDAADD"]
+    },
+    "ampharos-mega": {
+      "name": "Ampharosite",
+      "colours": ["#FFFF6E6A", "#FFFDDF4B", "#FFED1A24", "#FFB3CFEE"]
+    },
+    "audino-mega": {
+      "name": "Audinite",
+      "colours": ["#FFE7A4A6", "#FFFFF7D6", "#FFEE6A8C", "#FFFFDEE8"]
+    },
+    "banette-mega": {
+      "name": "Banettite",
+      "colours": ["#FFF49A2F", "#FF646263", "#FFF7EC6E", "#FFF6ADCC"]
+    },
+    "beedrill-mega": {
+      "name": "Beedrillite",
+      "colours": ["#FFCCA208", "#FF393939", "#FFF8C719", "#FFC4BCE6"]
+    },
+    "blastoise-mega": {
+      "name": "Blastoisinite",
+      "colours": ["#FF44B2D1", "#FF4B96CD", "#FF624A28", "#FFD3D2C7"]
+    },
+    "blaziken-mega": {
+      "name": "Blazikenite",
+      "colours": ["#FF88280F", "#FFEF2F2C", "#FF221F20", "#FFFDF1EC"]
+    },
+    "camerupt-mega": {
+      "name": "Cameruptite",
+      "colours": ["#FFC65A48", "#FF4B4A44", "#FFEC7159", "#FFBBAC9C"]
+    },
+    "charizard-mega-x": {
+      "name": "Charizardite X",
+      "colours": ["#FF22618C", "#FF484A4D", "#FF45BDE8", "#FF6EC2EC"]
+    },
+    "charizard-mega-y": {
+      "name": "Charizardite Y",
+      "colours": ["#FFFE9A15", "#FFED1A2E", "#FFE6EC21", "#FFF68648"]
+    },
+    "diancie-mega": {
+      "name": "Diancite",
+      "colours": ["#FFE0B572", "#FFE68AAB", "#FFF9EFA5", "#FFF4E4E5"]
+    },
+    "gallade-mega": {
+      "name": "Galladite",
+      "colours": ["#FFDA99A2", "#FF59A392", "#FFDB6273", "#FFEAEBD9"]
+    },
+    "garchomp-mega": {
+      "name": "Garchompite",
+      "colours": ["#FFF78613", "#FFEF2F2C", "#FFFAB30A", "#FF444868"]
+    },
+    "gardevoir-mega": {
+      "name": "Gardevoirite",
+      "colours": ["#FFD93670", "#FF94D87C", "#FFF263AF", "#FFB3CDEB"]
+    },
+    "gengar-mega": {
+      "name": "Gengarite",
+      "colours": ["#FFC1144C", "#FF493D61", "#FFEA1F3B", "#FFA3A9CF"]
+    },
+    "glalie-mega": {
+      "name": "Glalitite",
+      "colours": ["#FF3A6070", "#FF499ABA", "#FF3B3B3A", "#FFD4DAEC"]
+    },
+    "gyarados-mega": {
+      "name": "Gyaradosite",
+      "colours": ["#FF821976", "#FF3286CE", "#FFD7144B", "#FFCA922C"]
+    },
+    "heracross-mega": {
+      "name": "Heracronite",
+      "colours": ["#FFEA1F3A", "#FF27598F", "#FFF38351", "#FFF9DB3A"]
+    },
+    "houndoom-mega": {
+      "name": "Houndoominite",
+      "colours": ["#FFBF1C2C", "#FF303D39", "#FFEB2034", "#FFA25E7E"]
+    },
+    "kangaskhan-mega": {
+      "name": "Kangaskhanite",
+      "colours": ["#FFA57F9F", "#FFA3A9CE", "#FF515758", "#FFF8DE82"]
+    },
+    "latias-mega": {
+      "name": "Latiasite",
+      "colours": ["#FFC6509B", "#FF8B63D5", "#FFFF3138", "#FFBEC6FB"]
+    },
+    "latios-mega": {
+      "name": "Latiosite",
+      "colours": ["#FF5E73EB", "#FF8B63D6", "#FF2884F7", "#FFBDC6FC"]
+    },
+    "lopunny-mega": {
+      "name": "Lopunnite",
+      "colours": ["#FF6A423C", "#FFA16355", "#FF493A3B", "#FFF9F4BD"]
+    },
+    "lucario-mega": {
+      "name": "Lucarionite",
+      "colours": ["#FF752763", "#FF067891", "#FFB00D2E", "#FFF68536"]
+    },
+    "manectric-mega": {
+      "name": "Manectite",
+      "colours": ["#FFA5185A", "#FF4EB1CB", "#FFEB1F33", "#FFEDF588"]
+    },
+    "mawile-mega": {
+      "name": "Mawilite",
+      "colours": ["#FFB47226", "#FF4F4C4E", "#FFF9ED9A", "#FFF595CB"]
+    },
+    "medicham-mega": {
+      "name": "Medichamite",
+      "colours": ["#FFEE702E", "#FFEF3494", "#FFF8E082", "#FF6FC1ED"]
+    },
+    "metagross-mega": {
+      "name": "Metagrossite",
+      "colours": ["#FFB7B3B9", "#FFDA9B5B", "#FFCCCCCC", "#FF86BCD4"]
+    },
+    "mewtwo-mega-x": {
+      "name": "Mewtwonite X",
+      "colours": ["#FF27588F", "#FF8F6CA0", "#FF2E82B2", "#FFD1D1D2"]
+    },
+    "mewtwo-mega-y": {
+      "name": "Mewtwonite Y",
+      "colours": ["#FFB479C2", "#FF8F6CA0", "#FFE2C2E6", "#FFD1D1D2"]
+    },
+    "pidgeot-mega": {
+      "name": "Pidgeotite",
+      "colours": ["#FFAF879D", "#FFF7EF7C", "#FFDD4173", "#FFF79549"]
+    },
+    "pinsir-mega": {
+      "name": "Pinsirite",
+      "colours": ["#FFB04427", "#FFA1706A", "#FFF06F39", "#FFF8DC39"]
+    },
+    "sableye-mega": {
+      "name": "Sablenite",
+      "colours": ["#FFAE4076", "#FFE7285A", "#FF795A9C", "#FFFEDE7A"]
+    },
+    "salamence-mega": {
+      "name": "Salamencite",
+      "colours": ["#FF2B728B", "#FFE2595F", "#FF2A92BA", "#FFC4C5C6"]
+    },
+    "sceptile-mega": {
+      "name": "Sceptilite",
+      "colours": ["#FF97734A", "#FFDE6353", "#FF274928", "#FF74BC71"]
+    },
+    "scizor-mega": {
+      "name": "Scizorite",
+      "colours": ["#FF432629", "#FFEB1F3B", "#FF222D3B", "#FFC7ECF1"]
+    },
+    "sharpedo-mega": {
+      "name": "Sharpedonite",
+      "colours": ["#FFCFC490", "#FF3070A9", "#FFFBDD81", "#FFCDCCE5"]
+    },
+    "slowbro-mega": {
+      "name": "Slowbronite",
+      "colours": ["#FFDBC188", "#FFF4808C", "#FFF3EE89", "#FFBACDBC"]
+    },
+    "steelix-mega": {
+      "name": "Steelixite",
+      "colours": ["#FFB3CADA", "#FF3499E3", "#FFCCECF4", "#FF939AB3"]
+    },
+    "swampert-mega": {
+      "name": "Swampertite",
+      "colours": ["#FFAE6A6C", "#FFEF6A5B", "#FF49535B", "#FF72B4DB"]
+    },
+    "tyranitar-mega": {
+      "name": "Tyranitarite",
+      "colours": ["#FF5E1F27", "#FF1F1F26", "#FFB3193E", "#FFA0CA80"]
+    },
+    "venusaur-mega": {
+      "name": "Venusaurite",
+      "colours": ["#FFDB346F", "#FF1C7B74", "#FFF364A8", "#FF60B8CC"]
+    },
+    "absol-mega-z": {
+      "name": "Absolite Z",
+      "colours": ["#FF111014", "#FF2E6195", "#FFDB015A", "#FF00243C"]
+    },
+    "barbaracle-mega": {
+      "name": "Barbaracite",
+      "colours": ["#FFFCFEFE", "#FFCED1DE", "#FFF57757", "#FF2B3236"]
+    },
+    "baxcalibur-mega": {
+      "name": "Baxcalibrite",
+      "colours": ["#FFBA3E41", "#FF2F5E89", "#FFB0A4E6", "#FFC8EEEE"]
+    },
+    "chandelure-mega": {
+      "name": "Chandelurite",
+      "colours": ["#FFD7B179", "#FF302F30", "#FFDDEEFA", "#FF7447F9"]
+    },
+    "chesnaught-mega": {
+      "name": "Chesnaughtite",
+      "colours": ["#FFD9B638", "#FF467019", "#FF87112C", "#FFE9EADB"]
+    },
+    "chimecho-mega": {
+      "name": "Chimechite",
+      "colours": ["#FF367799", "#FFE54262", "#FFBADDE9", "#FFF4DB70"]
+    },
+    "clefable-mega": {
+      "name": "Clefablite",
+      "colours": ["#FFFFFEFE", "#FFFBE1D5", "#FFE45386", "#FFF78B9F"]
+    },
+    "crabominable-mega": {
+      "name": "Crabominite",
+      "colours": ["#FFE7CE42", "#FF4DC9EA", "#FF585478", "#FFFFFFFF"]
+    },
+    "darkrai-mega": {
+      "name": "Darkranite",
+      "colours": ["#FF000000", "#FFEDEDED", "#FFFF22DC", "#FF313031"]
+    },
+    "delphox-mega": {
+      "name": "Delphoxite",
+      "colours": ["#FFFDFDF8", "#FFE1523D", "#FFFBE67B", "#FF413146"]
+    },
+    "dragalge-mega": {
+      "name": "Dragalgite",
+      "colours": ["#FF6D7A4D", "#FF603731", "#FFC65065", "#FF996BE0"]
+    },
+    "dragonite-mega": {
+      "name": "Dragoninite",
+      "colours": ["#FFE256C3", "#FFF7F1D2", "#FF2CA796", "#FFEEBB6C"]
+    },
+    "drampa-mega": {
+      "name": "Drampanite",
+      "colours": ["#FFE3ECDD", "#FF3C4551", "#FF1C916D", "#FF67758E"]
+    },
+    "eelektross-mega": {
+      "name": "Eelektrossite",
+      "colours": ["#FFDE726D", "#FF1F5D74", "#FFF4DF64", "#FFFEFEFE"]
+    },
+    "emboar-mega": {
+      "name": "Emboarite",
+      "colours": ["#FFD2794A", "#FF454545", "#FFE6C550", "#FFDC5756"]
+    },
+    "excadrill-mega": {
+      "name": "Excadrite",
+      "colours": ["#FFA25457", "#FF5B4E4A", "#FFF9624C", "#FFBABDBD"]
+    },
+    "falinks-mega": {
+      "name": "Falinksite",
+      "colours": ["#FF02A3FF", "#FFE00200", "#FF2D2927", "#FFFFD302"]
+    },
+    "feraligatr-mega": {
+      "name": "Feraligite",
+      "colours": ["#FF4C7188", "#FFDB3B5C", "#FFFBE1A5", "#FF68BCE8"]
+    },
+    "floette-eternal-mega": {
+      "name": "Floettite",
+      "colours": ["#FFFFFFFF", "#FFDA0F3D", "#FF3E5BA9", "#FF383B3B"]
+    },
+    "froslass-mega": {
+      "name": "Froslassite",
+      "colours": ["#FFDC7164", "#FFFDFDFD", "#FF8677DC", "#FF8BC5E7"]
+    },
+    "garchomp-mega-z": {
+      "name": "Garchompite Z",
+      "colours": ["#FFFDCE5B", "#FFE73E0B", "#FFFFFFFF", "#FF484461"]
+    },
+    "glimmora-mega": {
+      "name": "Glimmoranite",
+      "colours": ["#FF6E76DC", "#FF4AD3C7", "#FF1B368F", "#FF2172EA"]
+    },
+    "golisopod-mega": {
+      "name": "Golisopite",
+      "colours": ["#FFE7DE70", "#FF873D99", "#FF000000", "#FF737A80"]
+    },
+    "golurk-mega": {
+      "name": "Golurkite",
+      "colours": ["#FF007097", "#FFEFD484", "#FFA05BAC", "#FF7CA8B0"]
+    },
+    "greninja-mega": {
+      "name": "Greninjite",
+      "colours": ["#FFF4F1B5", "#FF201F1F", "#FFDE6E82", "#FF68ACD6"]
+    },
+    "hawlucha-mega": {
+      "name": "Hawluchanite",
+      "colours": ["#FF363634", "#FF66B99A", "#FFE7C252", "#FFBF4131"]
+    },
+    "heatran-mega": {
+      "name": "Heatranite",
+      "colours": ["#FFFFE200", "#FFC9C9C9", "#FFFFA801", "#FFCF2C0E"]
+    },
+    "lucario-mega-z": {
+      "name": "Lucarionite Z",
+      "colours": ["#FF5B5F64", "#FF409CAA", "#FFAEBDC2", "#FFE3EB8A"]
+    },
+    "magearna-mega": {
+      "name": "Magearnite",
+      "colours": ["#FFFFFFFF", "#FFF9E27F", "#FFFF98ED", "#FFA91B2D"]
+    },
+    "malamar-mega": {
+      "name": "Malamarite",
+      "colours": ["#FFEFE77F", "#FFCD468A", "#FF58EBF5", "#FF787AA4"]
+    },
+    "meganium-mega": {
+      "name": "Meganiumite",
+      "colours": ["#FFFFFFFF", "#FFE14D52", "#FFE97EA7", "#FFC5FF9C"]
+    },
+    "meowstic-mega": {
+      "name": "Meowsticite",
+      "colours": ["#FF7DCBDC", "#FFFFFFFF", "#FFFFCD00", "#FF00528C"]
+    },
+    "pyroar-mega": {
+      "name": "Pyroarite",
+      "colours": ["#FF2689AB", "#FFF4E465", "#FF5D504F", "#FFCF192D"]
+    },
+    "raichu-mega-x": {
+      "name": "Raichunite X",
+      "colours": ["#FFE40029", "#FF393939", "#FF8B4A2D", "#FFFDDA00"]
+    },
+    "raichu-mega-y": {
+      "name": "Raichunite Y",
+      "colours": ["#FF020000", "#FFFEDB00", "#FF5B452B", "#FFF2A900"]
+    },
+    "scolipede-mega": {
+      "name": "Scolipite",
+      "colours": ["#FF29E1B0", "#FFAB599B", "#FF474C4B", "#FF897E90"]
+    },
+    "scovillain-mega": {
+      "name": "Scovillainite",
+      "colours": ["#FF292A28", "#FF406E50", "#FFDF4F32", "#FF5EAA5D"]
+    },
+    "scrafty-mega": {
+      "name": "Scraftinite",
+      "colours": ["#FF5F5F62", "#FFEC9E69", "#FFDA5957", "#FFEEECEE"]
+    },
+    "skarmory-mega": {
+      "name": "Skarmorite",
+      "colours": ["#FF5D6F90", "#FF3C4E6F", "#FFEA3D2C", "#FFE5C13B"]
+    },
+    "staraptor-mega": {
+      "name": "Staraptite",
+      "colours": ["#FFFCAD04", "#FFF96038", "#FF574F48", "#FFC7BEBD"]
+    },
+    "starmie-mega": {
+      "name": "Starminite",
+      "colours": ["#FF3B71C1", "#FFF7DB39", "#FFBF1636", "#FF7D79D1"]
+    },
+    "tatsugiri-mega": {
+      "name": "Tatsugirinite",
+      "colours": ["#FFFF692B", "#FFFFDE00", "#FFFF497A", "#FF00DE63"]
+    },
+    "victreebel-mega": {
+      "name": "Victreebelite",
+      "colours": ["#FFDC9AA4", "#FF9AC45C", "#FFF89669", "#FFE6DD55"]
+    },
+    "zeraora-mega": {
+      "name": "Zeraorite",
+      "colours": ["#FF6F7176", "#FFEEDB5A", "#FF80C5E6", "#FF363835"]
+    },
+    "zygarde-mega": {
+      "name": "Zygardite",
+      "colours": ["#FF346DC5", "#FF8BE044", "#FFD02228", "#FF504A41"]
+    }
+  }
+}

--- a/src/thutcore/java/thut/core/common/world/mobs/data/DataSync_Impl.java
+++ b/src/thutcore/java/thut/core/common/world/mobs/data/DataSync_Impl.java
@@ -181,6 +181,11 @@ public class DataSync_Impl implements DataSync
             this.setRegisterTag(data.getTag());
             var key = data.getTag() + data.getName();
             var _data = old.getOrDefault(key, data);
+            if (_data != data)
+            {
+                // Preserve references held by capabilities while still applying the initial value from the server.
+                _data.setRaw(data.get());
+            }
             this.register(_data);
         });
         needInit = false;


### PR DESCRIPTION
## Summary

- Add names and four-layer colour palettes for the 92 Mega Stones.
- Apply the indexed name and colours when a blank Mega Stone converts, unless it already has a custom name.
- Leave Rayquaza without a Mega Stone, as intended.
- Mark the legacy individual Mega Stone sprite assets as deprecated in favor of the indexed tint colours.
- Fix initial synchronized values being discarded when existing data holders are reused. This prevents the Pokéwatch from showing incorrect happiness until the value changes.

## Testing

- Built and tested the Pokécube AIO JAR.
- Verified the names and colours of several converted Mega Stones, including X/Y variants.
- Verified Rayquaza is not assigned a Mega Stone.
- Verified the Pokéwatch reports the correct happiness for newly sent-out pokemobs.
