### PR TITLE
Fix genetics machines, selector books, and clone behavior

### DIFF
--- a/src/adventures/java/pokecube/adventures/Config.java
+++ b/src/adventures/java/pokecube/adventures/Config.java
@@ -133,6 +133,8 @@ public class Config extends ConfigData
     public boolean autoAddFossilDNA = true;
     @Configure(category = Config.MACHINE, comment = "Used to scale the energy cost of genetics machines, x is the original energy input. [Default: x]")
     public String clonerEfficiencyFunction = "x";
+    @Configure(category = Config.MACHINE, comment = "Clones devolve to base species. [Default: false]")
+    public boolean clonesDevolveToBaseSpecies = false;
 
     // Options related to warp pad
     @Configure(category = Config.MACHINE, comment = "Energy cost of Warp Pad teleportation, dw is 0 for the same dimension, varies otherwise. [Default: (dx)*(dx) + (dy)*(dy) + (dz)*(dz) + (5*dw)^4]")

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/extractor/ExtractorTile.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/extractor/ExtractorTile.java
@@ -1,6 +1,7 @@
 package pokecube.adventures.blocks.genetics.extractor;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup.Provider;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionResult;
@@ -32,6 +33,13 @@ public class ExtractorTile extends BaseGeneticsTile
         return ItemList.is(EXTRACT_DEST, stack);
     }
 
+    public static boolean isValidDestination(final Provider access, final ItemStack stack)
+    {
+        if (stack.isEmpty() || !isDNAContainer(stack)) return false;
+        var genes = ClonerHelper.getGenes(access, stack);
+        return genes == null || genes.getAlleles().isEmpty();
+    }
+
     public ItemStack override_selector = ItemStack.EMPTY;
 
     public ExtractorTile(final BlockPos pos, final BlockState state)
@@ -51,13 +59,10 @@ public class ExtractorTile extends BaseGeneticsTile
         switch (index)
         {
         case 0:// DNA Container
-            if (!isDNAContainer(stack)) return false;
-            var genes = ClonerHelper.getGenes(access, stack);
-            return genes == null || genes.getAlleles().isEmpty();
+            return isValidDestination(access, stack);
         case 1:// DNA Selector
             final boolean hasGenes = !ClonerHelper.getGeneSelectors(access, stack).isEmpty();
-            final boolean selector = hasGenes || RecipeSelector.getSelectorValue(stack) != SelectorImpl.defaultSelector;
-            return hasGenes || selector;
+            return hasGenes || !RecipeSelector.getSelectorValue(stack).equals(SelectorImpl.defaultSelector);
         case 2:// DNA Source
             // TODO decide on whether to search recipes to see if it is valid.
             return true;

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeClone.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeClone.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import pokecube.adventures.Config;
 import pokecube.adventures.blocks.genetics.cloner.ClonerTile;
 import pokecube.adventures.blocks.genetics.helper.ClonerHelper;
 import pokecube.adventures.blocks.genetics.helper.crafting.PoweredCraftingInventory;
@@ -188,6 +189,7 @@ public class RecipeClone extends PoweredRecipe
     {
         final BlockPos pos = ((BlockEntity) tile).getBlockPos();
         Alleles<SpeciesGene.SpeciesInfo, SpeciesGene> alleles = getEntry(tile, world);
+        if (Config.instance.clonesDevolveToBaseSpecies) alleles = toBaseSpecies(alleles);
         if (alleles == null) return false;
         PokedexEntry entry = alleles.getExpressed().getValue().getEntry();
         if (entry == Database.missingno) return false;
@@ -200,7 +202,7 @@ public class RecipeClone extends PoweredRecipe
             IPokemob pokemob = PokemobCaps.getPokemobFor(entity);
 
             var genes = ClonerHelper.getGenes(world.registryAccess(), dnaSource);
-            IMobGenetics sourceGenes = genes == null ? new DefaultGenetics() : genes;
+            IMobGenetics sourceGenes = copyGenes(world.registryAccess(), genes);
 
             this._genes.forEach((k, list2) -> {
                 var gene_1 = list2.get(world.getRandom().nextInt(list2.size()));
@@ -249,6 +251,38 @@ public class RecipeClone extends PoweredRecipe
         }
         if (tile.getCraftMatrix().eventHandler != null) tile.getCraftMatrix().eventHandler.broadcastChanges();
         return true;
+    }
+
+    private static IMobGenetics copyGenes(final Provider access, final IMobGenetics genes)
+    {
+        final IMobGenetics copy = new DefaultGenetics();
+        if (genes != null) copy.deserializeNBT(access, genes.serializeNBT(access));
+        return copy;
+    }
+
+    private static Alleles<SpeciesGene.SpeciesInfo, SpeciesGene> toBaseSpecies(
+            final Alleles<SpeciesGene.SpeciesInfo, SpeciesGene> source)
+    {
+        if (source == null) return null;
+        final SpeciesGene first = toBaseSpecies(source.getAllele(0));
+        final SpeciesGene second = toBaseSpecies(source.getAllele(1));
+        final SpeciesGene expressed = toBaseSpecies(source.getExpressed());
+        final Alleles<SpeciesGene.SpeciesInfo, SpeciesGene> result = new Alleles<>(first, second);
+        result.setExpressed(expressed);
+        return result;
+    }
+
+    private static SpeciesGene toBaseSpecies(final SpeciesGene source)
+    {
+        final SpeciesGene.SpeciesInfo sourceInfo = source.getValue();
+        final SpeciesGene.SpeciesInfo resultInfo = new SpeciesGene.SpeciesInfo();
+        final byte sex = sourceInfo.getSexe();
+        final PokedexEntry child = sourceInfo.getEntry().getChild();
+        resultInfo.setSexe(sex);
+        resultInfo.setEntry(child.getForGender(sex));
+        final SpeciesGene result = new SpeciesGene();
+        result.setValue(resultInfo);
+        return result;
     }
 
     @Override

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeExtract.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeExtract.java
@@ -8,6 +8,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.core.HolderLookup.Provider;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
@@ -190,12 +191,17 @@ public class RecipeExtract extends PoweredRecipe
         if (!(inv.inventory instanceof ExtractorTile tile)) return false;
         var access = worldIn.registryAccess();
 
+        ItemStack destination = inv.getItem(0);
+        if (!ExtractorTile.isValidDestination(access, destination)) return false;
+
         ItemStack source = inv.getItem(2);
         if (!this.input.isEmpty() && !this.input.test(source)) return false;
         IMobGenetics genes = ClonerHelper.getGenes(access, source);
         if (genes == null) genes = new DefaultGenetics();
 
-        ItemStack selector = tile.override_selector.isEmpty() ? inv.getItem(1) : tile.override_selector;
+        ItemStack slottedSelector = inv.getItem(1);
+        if (ClonerHelper.getGeneSelectors(access, slottedSelector).isEmpty()) return false;
+        ItemStack selector = tile.override_selector.isEmpty() ? slottedSelector : tile.override_selector;
         if (ClonerHelper.getGeneSelectors(access, selector).isEmpty()) selector = ItemStack.EMPTY;
         if (!this._genes.isEmpty())
         {
@@ -215,12 +221,15 @@ public class RecipeExtract extends PoweredRecipe
         if (!(inv.inventory instanceof ExtractorTile tile)) return ItemStack.EMPTY;
 
         final ItemStack destination = inv.getItem(0);
+        if (!ExtractorTile.isValidDestination(access, destination)) return ItemStack.EMPTY;
         ItemStack source = inv.getItem(2);
         if (!this.input.isEmpty() && !this.input.test(source)) return ItemStack.EMPTY;
         IMobGenetics genes = ClonerHelper.getGenes(access, source);
         if (genes == null) genes = new DefaultGenetics();
 
-        ItemStack selector = tile.override_selector.isEmpty() ? inv.getItem(1) : tile.override_selector;
+        ItemStack slottedSelector = inv.getItem(1);
+        if (ClonerHelper.getGeneSelectors(access, slottedSelector).isEmpty()) return ItemStack.EMPTY;
+        ItemStack selector = tile.override_selector.isEmpty() ? slottedSelector : tile.override_selector;
         if (ClonerHelper.getGeneSelectors(access, selector).isEmpty()) selector = ItemStack.EMPTY;
         boolean forcedGenes = false;
         if (!this._genes.isEmpty())
@@ -282,16 +291,21 @@ public class RecipeExtract extends PoweredRecipe
                 else if (potion) nonnulllist.set(i, new ItemStack(Items.GLASS_BOTTLE));
                 else if (!multiple)
                 {
-                    item = item.copy();
-                    var comp1 = item.remove(PokemobCaps.POKECUBE_DATA);
-                    var comp2 = item.remove(DefaultGenetics.GENE_STORE);
-                    if (comp1 != null || comp2 != null) nonnulllist.set(i, item);
-                    else nonnulllist.set(i, ItemStack.EMPTY);
+                    nonnulllist.set(i, clearDNA(item));
                 }
             }
             if (item.hasCraftingRemainingItem()) nonnulllist.set(i, item.getCraftingRemainingItem());
         }
         tile.override_selector = ItemStack.EMPTY;
         return nonnulllist;
+    }
+
+    static ItemStack clearDNA(final ItemStack stack)
+    {
+        final ItemStack cleared = stack.copy();
+        final var pokemob = cleared.remove(PokemobCaps.POKECUBE_DATA);
+        final var genes = cleared.remove(DefaultGenetics.GENE_STORE);
+        if (pokemob != null) cleared.remove(DataComponents.ITEM_NAME);
+        return pokemob != null || genes != null ? cleared : ItemStack.EMPTY;
     }
 }

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeHandlers.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeHandlers.java
@@ -1,8 +1,12 @@
 package pokecube.adventures.blocks.genetics.helper.recipe;
 
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent.ItemCraftedEvent;
-import pokecube.adventures.PokecubeAdv;
-import pokecube.core.PokecubeCore;
+import pokecube.adventures.blocks.genetics.helper.SelectorImpl;
+import pokecube.adventures.blocks.genetics.helper.SelectorImpl.SelectorValue;
 import thut.core.common.ThutCore;
 
 public class RecipeHandlers
@@ -34,18 +38,30 @@ public class RecipeHandlers
 
     public static void init()
     {
+        RecipeSelector.clear();
+        RecipeSelector.addSelector(Ingredient.of(Items.NETHER_STAR), new SelectorValue(0.25f, 0.0f));
         ThutCore.FORGE_BUS.addListener(RecipeHandlers::onCrafted);
     }
 
     private static void onCrafted(final ItemCraftedEvent event)
     {
-        if(PokecubeCore.getConfig().debug_data) Thread.dumpStack();
-        //        if (!(event.getInventory() instanceof CraftingContainer inv)) return;
-        //        final BookCloningRecipe test = new BookCloningRecipe(CraftingBookCategory.MISC);
-        //
-        //        if (!test.matches(inv, event.getEntity().level())) return;
-        //        final SelectorValue value = ClonerHelper.getSelectorValue(event.getCrafting());
-        //        if (value == SelectorImpl.defaultSelector) return;
-        //        event.getCrafting().getTag().remove(ClonerHelper.SELECTORTAG);
+        final ItemStack result = event.getCrafting();
+        if (result.has(SelectorImpl.VALUE_STORE) && isBookCopy(event.getInventory()))
+            result.remove(SelectorImpl.VALUE_STORE);
+    }
+
+    private static boolean isBookCopy(final Container inventory)
+    {
+        int writtenBooks = 0;
+        int writableBooks = 0;
+        for (int i = 0; i < inventory.getContainerSize(); i++)
+        {
+            final ItemStack stack = inventory.getItem(i);
+            if (stack.isEmpty()) continue;
+            if (stack.is(Items.WRITTEN_BOOK)) writtenBooks++;
+            else if (stack.is(Items.WRITABLE_BOOK)) writableBooks += stack.getCount();
+            else return false;
+        }
+        return writtenBooks == 1 && writableBooks > 0;
     }
 }

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeSelector.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeSelector.java
@@ -119,7 +119,7 @@ public class RecipeSelector extends CustomRecipe
                 book = test;
                 continue;
             }
-            final boolean isModifier = RecipeSelector.getSelectorValue(test) != SelectorImpl.defaultSelector;
+            final boolean isModifier = !RecipeSelector.getSelectorValue(test).equals(SelectorImpl.defaultSelector);
             if (isModifier)
             {
                 if (!modifier.isEmpty()) return ItemStack.EMPTY;
@@ -130,7 +130,6 @@ public class RecipeSelector extends CustomRecipe
         }
         if (book.isEmpty() || modifier.isEmpty()) return ItemStack.EMPTY;
         final SelectorValue value = RecipeSelector.getSelectorValue(modifier);
-        ClonerHelper.getSelectorValue(book);
         final ItemStack ret = book.copy();
         ret.setCount(1);
         ret.set(SelectorImpl.VALUE_STORE, value);
@@ -158,7 +157,7 @@ public class RecipeSelector extends CustomRecipe
                 book = test;
                 continue;
             }
-            final boolean isModifier = RecipeSelector.getSelectorValue(test) != SelectorImpl.defaultSelector;
+            final boolean isModifier = !RecipeSelector.getSelectorValue(test).equals(SelectorImpl.defaultSelector);
             if (isModifier)
             {
                 if (!modifier.isEmpty()) return false;

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeSplice.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/helper/recipe/RecipeSplice.java
@@ -15,7 +15,6 @@ import pokecube.adventures.blocks.genetics.splicer.SplicerTile;
 import pokecube.adventures.utils.RecipePokeAdv;
 
 import java.util.List;
-import java.util.function.Function;
 
 public class RecipeSplice extends PoweredRecipe
 {
@@ -56,9 +55,11 @@ public class RecipeSplice extends PoweredRecipe
         var access = worldIn.registryAccess();
         ItemStack dna = inv.getItem(0);
         ItemStack egg = inv.getItem(2);
-        ItemStack selector = tile.override_selector.isEmpty() ? inv.getItem(1) : tile.override_selector;
-        if (ClonerHelper.getGenes(access, dna) == null) dna = ItemStack.EMPTY;
-        if (ClonerHelper.getGenes(access, egg) == null) egg = ItemStack.EMPTY;
+        ItemStack slottedSelector = inv.getItem(1);
+        if (ClonerHelper.getGeneSelectors(access, slottedSelector).isEmpty()) return false;
+        ItemStack selector = tile.override_selector.isEmpty() ? slottedSelector : tile.override_selector;
+        if (!hasGenes(access, dna)) dna = ItemStack.EMPTY;
+        if (!hasGenes(access, egg)) egg = ItemStack.EMPTY;
         if (ClonerHelper.getGeneSelectors(access, selector).isEmpty()) selector = ItemStack.EMPTY;
         return !selector.isEmpty() && !dna.isEmpty() && !egg.isEmpty();
     }
@@ -71,9 +72,11 @@ public class RecipeSplice extends PoweredRecipe
         ItemStack output = ItemStack.EMPTY;
         ItemStack dna = inv.getItem(0);
         ItemStack egg = inv.getItem(2);
-        ItemStack selector = tile.override_selector.isEmpty() ? inv.getItem(1) : tile.override_selector;
-        if (ClonerHelper.getGenes(access, dna) == null) dna = ItemStack.EMPTY;
-        if (ClonerHelper.getGenes(access, egg) == null) egg = ItemStack.EMPTY;
+        ItemStack slottedSelector = inv.getItem(1);
+        if (ClonerHelper.getGeneSelectors(access, slottedSelector).isEmpty()) return ItemStack.EMPTY;
+        ItemStack selector = tile.override_selector.isEmpty() ? slottedSelector : tile.override_selector;
+        if (!hasGenes(access, dna)) dna = ItemStack.EMPTY;
+        if (!hasGenes(access, egg)) egg = ItemStack.EMPTY;
         if (ClonerHelper.getGeneSelectors(access, selector).isEmpty()) selector = ItemStack.EMPTY;
         if (!selector.isEmpty() && !dna.isEmpty() && !egg.isEmpty())
         {
@@ -115,13 +118,19 @@ public class RecipeSplice extends PoweredRecipe
                 else if (item.getItem() == Items.POTION) nonnulllist.set(i, new ItemStack(Items.GLASS_BOTTLE));
                 else if (!multiple)
                 {
-                    nonnulllist.set(i, item.copyAndClear());
+                    nonnulllist.set(i, RecipeExtract.clearDNA(item));
                 }
             }
             if (item.hasCraftingRemainingItem()) nonnulllist.set(i, item.getCraftingRemainingItem());
         }
         tile.override_selector = ItemStack.EMPTY;
         return nonnulllist;
+    }
+
+    private static boolean hasGenes(final Provider access, final ItemStack stack)
+    {
+        final var genes = ClonerHelper.getGenes(access, stack);
+        return genes != null && !genes.getAlleles().isEmpty();
     }
 
     @Override

--- a/src/adventures/java/pokecube/adventures/blocks/genetics/splicer/SplicerTile.java
+++ b/src/adventures/java/pokecube/adventures/blocks/genetics/splicer/SplicerTile.java
@@ -42,13 +42,14 @@ public class SplicerTile extends BaseGeneticsTile
         switch (index)
         {
         case 0:// DNA Container
-            return ClonerHelper.getGenes(access, stack) != null;
+            var sourceGenes = ClonerHelper.getGenes(access, stack);
+            return sourceGenes != null && !sourceGenes.getAlleles().isEmpty();
         case 1:// DNA Selector
             final boolean hasGenes = !ClonerHelper.getGeneSelectors(access, stack).isEmpty();
-            final boolean selector = hasGenes || RecipeSelector.getSelectorValue(stack) != SelectorImpl.defaultSelector;
-            return hasGenes || selector;
+            return hasGenes || !RecipeSelector.getSelectorValue(stack).equals(SelectorImpl.defaultSelector);
         case 2:// DNA Destination
-            return ClonerHelper.getGenes(access, stack) != null;
+            var destinationGenes = ClonerHelper.getGenes(access, stack);
+            return destinationGenes != null && !destinationGenes.getAlleles().isEmpty();
         }
         return false;
     }


### PR DESCRIPTION
## Summary

- Restore Nether Star gene-selector crafting and prevent selector enhancements from being duplicated through written-book copying.
- Require valid source, selector, and destination items for genetics operations, and correctly clear consumed genetic and Pokécube name data.
- Safely copy genetics when cloning and add a `clonesDevolveToBaseSpecies` config option, defaulting to `false`.

## Testing

- Built and launched the Pokecube AIO 1.21.1 test JAR.
- Tested the Extractor, Splicer, Cloner, selector crafting, book-copy protection, and all selector elements.
- Verified both settings of `clonesDevolveToBaseSpecies`: evolved forms are preserved by default and converted to base species when enabled.
