### PR TITLE
Guard Pokemob texture lookup before model initialization

### DIFF
--- a/src/pokecube/java/pokecube/core/client/render/mobs/RenderPokemob.java
+++ b/src/pokecube/java/pokecube/core/client/render/mobs/RenderPokemob.java
@@ -350,6 +350,7 @@ public class RenderPokemob extends MobRenderer<Mob, ModelWrapper<Mob>>
         @Override
         public IPartTexturer getTexturer()
         {
+            if (this.wrapper == null) return null;
             if (this.wrapper.texChangeHolder.get() == null) this.setTexturer(new PokemobTexHelper(entry));
             return this.wrapper.texChangeHolder.get();
         }


### PR DESCRIPTION
## Summary

- Avoid accessing a Pokemob texturer before its model wrapper has initialized.
- Allow the existing base-texture fallback to handle early texture requests from map integrations.

## Root cause

During a cold client load, Xaero can request Pokemob entity textures before the corresponding model wrapper is ready. `getTexturer()` accessed the wrapper unconditionally, producing repeated render-thread exceptions while radar icon resources were loading.

## Testing

- Reproduced with current Iris and Sodium versions, both Xaero maps, and no shader pack.
- After the fix, Xaero reloaded its radar icon resources with no matching exceptions.
- Built and loaded the patched Pokecube AIO successfully, then confirmed a normal shutdown.