### PR TITLE
Made pokemob's held and offhand items transfer into the player's inventory on pokeplayer transform

### DIFF
--- a/src/pokecube/java/pokecube/gimmicks/pokeplayer/blocks/TransformBlock.java
+++ b/src/pokecube/java/pokecube/gimmicks/pokeplayer/blocks/TransformBlock.java
@@ -6,6 +6,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -35,27 +36,40 @@ public class TransformBlock extends Block {
     protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos,
             Player player, InteractionHand hand, BlockHitResult hitResult)
     {
-        if(!(player instanceof ServerPlayer)) return ItemInteractionResult.SUCCESS;
+        if (!(player instanceof ServerPlayer)) return ItemInteractionResult.SUCCESS;
+
         var copy = ThutCaps.getCopyMob(player);
         boolean notTransformed = copy == null || copy.getCopiedID() == null;
         boolean isFilled = PokemobCaps.isFilled(stack);
+
         // Not transformed, and holding a filled cube, transform the player
-        if(notTransformed && isFilled) {
+        if (notTransformed && isFilled) {
             var pokemob = PokemobCaps.getPokemobIn(stack, level).pokemob();
-            if(pokemob != null) pokemob.setPokecube(stack);
+
+            if (pokemob != null) pokemob.setPokecube(stack);
+
+            player.addItem(pokemob.getHeldItem()); // Transfer pokemob held and offhand items to player
+            player.addItem(pokemob.getEntity().getOffhandItem());
+            pokemob.setHeldItem(ItemStack.EMPTY);
+            pokemob.getEntity().setItemInHand(InteractionHand.OFF_HAND, ItemStack.EMPTY);
+
             Pokeplayer.transformPlayer(pokemob, player);
             player.setItemInHand(hand, ItemStack.EMPTY);
             return ItemInteractionResult.CONSUME;
         }
         // If transformed, revert the player
-        if(!notTransformed) {
+        if (!notTransformed) {
             var mob = copy.getCopiedMob();
             var pokemob = PokemobCaps.getPokemobFor(mob);
+
+            pokemob.setHeldItem(ItemStack.EMPTY); // Remove held and offhand items to prevent cloning
+            mob.setItemInHand(InteractionHand.OFF_HAND, ItemStack.EMPTY);
             pokemob.setHealth(pokemob.getMaxHealth());
+
             var cube = new ItemStack(PokecubeItems.getEmptyCube(ResourceLocation.parse("pokecube:pokecube")));
-            if(pokemob != null && !pokemob.getPokecube().isEmpty()) cube = pokemob.getPokecube();
+            if (pokemob != null && !pokemob.getPokecube().isEmpty()) cube = pokemob.getPokecube();
             PokecubeManager.addToCube(cube, mob);
-            if(!player.addItem(cube));// Should drop in here instead.
+            if (!player.addItem(cube));// Should drop in here instead.
             Pokeplayer.transformPlayer(null, player);
         }
         return ItemInteractionResult.SUCCESS;


### PR DESCRIPTION
Made pokemob's held and offhand items transfer into the player's inventory on pokeplayer transform, removed pokemob's held and offhand items on reversion (prevents cloning specifically of offhand items)